### PR TITLE
[go] Prototype Bubble Tea run-from-readme

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -66,6 +66,12 @@ An experimental Rust reimplementation of both `my-fuzzy-finder` and its fuzzy ma
 directory.
 
 
+## `run-from-readme`
+
+`run-from-readme` is a Bubble Tea-based TUI for extracting shell snippets from a README, interactively filtering them,
+and emitting either a Nushell-escaped command or the raw snippet.
+
+
 ## `claude-sandboxed`
 
 Launch Claude Code in a sandbox where network and file system access is restricted. 
@@ -140,17 +146,25 @@ Follow these instructions to build, run and install my software.
     * ```nushell
       do run my-fuzzy-finder --example --debug
       ```
-4. Build all executables:
+4. Build and run the `run-from-readme` program:
+    * ```nushell
+      do run run-from-readme ../mac-os/README.md
+      ```
+    * Type to filter interactively.
+    * Use `Enter` to run the selected snippet with its default action.
+    * Use `Ctrl+O` to run the focused snippet as-is and remember that default for future sessions.
+    * Use `Ctrl+E` to run the focused snippet escaped one time without changing the saved default.
+5. Build all executables:
     * ```nushell
       do build
       ```
     * The executables will be in the `bin/` directory. Try them out as needed to do validation and exploration. If you are satisfied, then you can install the executables globally with the next step.
-5. Build and install the executables to your `GOBIN`:
+6. Build and install the executables to your `GOBIN`:
     * ```nushell
       do install
       ```
     * Now you can run the executables from anywhere on your system.
-6. Demonstrate `my-node-launcher`
+7. Demonstrate `my-node-launcher`
     * Copy the launcher into the example JS app.
     * ```nushell
       cp bin/my-node-launcher example-js-app/capitalize

--- a/go/do.nu
+++ b/go/do.nu
@@ -18,6 +18,16 @@ export def --wrapped "run my-fuzzy-finder" [...args] {
     }
 }
 
+export def --wrapped "run run-from-readme" [...args] {
+    let _in = $in
+    cd $DIR
+    if ($_in | is-empty) {
+        go run my-software/pkg/run-from-readme ...$args
+    } else {
+        $_in | (go run my-software/pkg/run-from-readme ...$args)
+    }
+}
+
 export def build [] {
     cd $DIR
     mkdir bin; go build -o bin  './...'

--- a/go/pkg/run-from-readme/main.go
+++ b/go/pkg/run-from-readme/main.go
@@ -1,0 +1,816 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	fz "my-software/pkg/my-fuzzy-finder-lib"
+)
+
+const (
+	noMatchExitCode     = 1
+	noSelectionExitCode = 130
+	queryCharLimit      = 64
+	preferenceFileName  = "preferences.json"
+)
+
+var (
+	frameStyle = lipgloss.NewStyle().Margin(1, 2)
+	plainStyle = lipgloss.NewStyle()
+	accent     = lipgloss.Color("#DA5CE4")
+	muted      = lipgloss.Color("245")
+	promptGray = lipgloss.Color("100")
+
+	styleTitle = lipgloss.NewStyle().Bold(true)
+	styleMuted = lipgloss.NewStyle().Foreground(muted)
+	styleAccent = lipgloss.NewStyle().Foreground(accent)
+	styleSelected = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(accent).
+			Padding(0, 0, 0, 1)
+	styleNormal = lipgloss.NewStyle().Padding(0, 0, 0, 2)
+	styleSaved  = lipgloss.NewStyle().Foreground(accent).Bold(true)
+	styleHelp   = lipgloss.NewStyle().Foreground(muted)
+	styleLang   = lipgloss.NewStyle().Foreground(lipgloss.Color("0"))
+	stylePreview = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(muted).
+			Padding(0, 1)
+)
+
+type runMode string
+
+const (
+	runModeEscaped runMode = "escaped"
+	runModeAsIs    runMode = "as-is"
+)
+
+type action int
+
+const (
+	actionDefault action = iota
+	actionRunAsIs
+	actionRunEscaped
+)
+
+type snippet struct {
+	Language string `json:"language"`
+	Content  string `json:"content"`
+}
+
+func (s snippet) key() string {
+	sum := sha256.Sum256([]byte(s.Language + "\x00" + s.Content))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s snippet) isNu() bool {
+	return s.Language == "nushell"
+}
+
+func (s snippet) isShellLike() bool {
+	switch s.Language {
+	case "shell", "bash", "sh":
+		return true
+	default:
+		return false
+	}
+}
+
+type snippetEntry struct {
+	Snippet       snippet
+	RememberedAsIs bool
+}
+
+func (e snippetEntry) defaultRunMode() runMode {
+	if e.Snippet.isNu() || e.RememberedAsIs {
+		return runModeAsIs
+	}
+	return runModeEscaped
+}
+
+func (e snippetEntry) header() string {
+	var b strings.Builder
+	if e.RememberedAsIs {
+		b.WriteString("[saved] ")
+	}
+	fmt.Fprintf(&b, "[%s] [default: %s", e.Snippet.Language, e.defaultRunMode())
+	if e.RememberedAsIs {
+		b.WriteString(", remembered")
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func (e snippetEntry) filterText() string {
+	return e.header() + "\n" + e.Snippet.Content
+}
+
+type match struct {
+	Index     int
+	Positions []int
+}
+
+type selectionOutput struct {
+	Index          int     `json:"index"`
+	Language       string  `json:"language"`
+	Content        string  `json:"content"`
+	RunMode        runMode `json:"run_mode"`
+	Command        string  `json:"command"`
+	RememberedAsIs bool    `json:"remembered_as_is"`
+}
+
+type preferences struct {
+	RunAsIs map[string]map[string]bool `json:"run_as_is"`
+}
+
+func loadPreferences() (preferences, error) {
+	dir, err := preferencesDir()
+	if err != nil {
+		return preferences{}, err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return preferences{}, err
+	}
+	path := filepath.Join(dir, preferenceFileName)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return preferences{RunAsIs: map[string]map[string]bool{}}, nil
+	}
+	if err != nil {
+		return preferences{}, err
+	}
+	var prefs preferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return preferences{}, err
+	}
+	if prefs.RunAsIs == nil {
+		prefs.RunAsIs = map[string]map[string]bool{}
+	}
+	return prefs, nil
+}
+
+func savePreferences(prefs preferences) error {
+	dir, err := preferencesDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, preferenceFileName)
+	data, err := json.MarshalIndent(prefs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func preferencesDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".run-from-readme-go"), nil
+}
+
+type keyMap struct {
+	Up         key.Binding
+	Down       key.Binding
+	Accept     key.Binding
+	RunAsIs    key.Binding
+	RunEscaped key.Binding
+	Cancel     key.Binding
+}
+
+func defaultKeyMap() keyMap {
+	return keyMap{
+		Up:         key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous")),
+		Down:       key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next")),
+		Accept:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "run default")),
+		RunAsIs:    key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("ctrl+o", "run as-is + save")),
+		RunEscaped: key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("ctrl+e", "run escaped once")),
+		Cancel:     key.NewBinding(key.WithKeys("esc", "ctrl+c"), key.WithHelp("esc", "cancel")),
+	}
+}
+
+type model struct {
+	keys          keyMap
+	input         textinput.Model
+	readmePath    string
+	entries       []snippetEntry
+	filterTexts   []string
+	matches       []match
+	selected      int
+	width         int
+	height        int
+	frame         lipgloss.Style
+	action        *action
+	completed     bool
+}
+
+func newModel(readmePath string, entries []snippetEntry, initialQuery string) model {
+	input := textinput.New()
+	input.Prompt = "Filter: "
+	input.PromptStyle = lipgloss.NewStyle().Foreground(promptGray)
+	input.Cursor.Style = lipgloss.NewStyle().Foreground(accent)
+	input.CharLimit = queryCharLimit
+	input.Focus()
+	input.SetValue(initialQuery)
+	filterTexts := make([]string, len(entries))
+	for i, entry := range entries {
+		filterTexts[i] = entry.filterText()
+	}
+	m := model{
+		keys:        defaultKeyMap(),
+		input:       input,
+		readmePath:  readmePath,
+		entries:     entries,
+		filterTexts: filterTexts,
+		selected:    0,
+		frame:       frameStyle,
+	}
+	m.refreshMatches()
+	return m
+}
+
+func (m model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		if msg.Width <= 70 || msg.Height <= 16 {
+			m.frame = plainStyle
+		} else {
+			m.frame = frameStyle
+		}
+		hz, _ := m.frame.GetFrameSize()
+		m.input.Width = max(10, msg.Width-hz-lipgloss.Width(m.input.Prompt)-4)
+		return m, nil
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.Cancel):
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Accept):
+			act := actionDefault
+			m.action = &act
+			m.completed = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.RunAsIs):
+			act := actionRunAsIs
+			m.action = &act
+			m.completed = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.RunEscaped):
+			act := actionRunEscaped
+			m.action = &act
+			m.completed = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Up):
+			if len(m.matches) > 0 && m.selected > 0 {
+				m.selected--
+			}
+			return m, nil
+		case key.Matches(msg, m.keys.Down):
+			if len(m.matches) > 0 && m.selected < len(m.matches)-1 {
+				m.selected++
+			}
+			return m, nil
+		}
+	}
+
+	oldQuery := m.input.Value()
+	m.input, cmd = m.input.Update(msg)
+	if m.input.Value() != oldQuery {
+		m.refreshMatches()
+	}
+	return m, cmd
+}
+
+func (m *model) refreshMatches() {
+	query := m.input.Value()
+	if query == "" {
+		m.matches = make([]match, len(m.entries))
+		for i := range m.entries {
+			m.matches[i] = match{Index: i}
+		}
+	} else {
+		m.matches = m.matches[:0]
+		pattern := fz.BuildPattern(query)
+		for i, text := range m.filterTexts {
+			if ok, positions := pattern.MatchItem(strings.ToLower(text)); ok {
+				m.matches = append(m.matches, match{Index: i, Positions: positions})
+			}
+		}
+	}
+	if len(m.matches) == 0 {
+		m.selected = 0
+		return
+	}
+	if m.selected >= len(m.matches) {
+		m.selected = len(m.matches) - 1
+	}
+}
+
+func (m model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+
+	helpLine1 := lipgloss.JoinHorizontal(lipgloss.Left,
+		styleAccent.Render("Enter"), " run default   ",
+		styleAccent.Render("Ctrl+O"), " run as-is + save   ",
+		styleAccent.Render("Ctrl+E"), " run escaped once   ",
+		styleAccent.Render("Esc"), " cancel",
+	)
+
+	defaultText := "n/a"
+	if entry := m.selectedEntry(); entry != nil {
+		defaultText = string(entry.defaultRunMode())
+	}
+	helpLine2 := lipgloss.JoinHorizontal(lipgloss.Left,
+		"Selected default: ",
+		styleAccent.Render(defaultText),
+		"   ",
+		styleHelp.Render("[saved] marks snippets whose Enter default is remembered"),
+	)
+
+	body := m.renderBody()
+	sections := []string{
+		m.input.View(),
+		helpLine1,
+		helpLine2,
+		body,
+	}
+	return m.frame.Render(lipgloss.JoinVertical(lipgloss.Left, sections...))
+}
+
+func (m model) renderBody() string {
+	if len(m.matches) == 0 {
+		return styleMuted.Render("No matches.")
+	}
+
+	listWidth := max(36, m.width/2)
+	if m.width < 100 {
+		listWidth = max(28, m.width/2-2)
+	}
+	previewWidth := max(24, m.width-listWidth-8)
+
+	var rows []string
+	for i, match := range m.matches {
+		entry := m.entries[match.Index]
+		rendered := renderEntry(entry, i == m.selected)
+		if i == m.selected {
+			rendered = styleSelected.Width(listWidth).Render(rendered)
+		} else {
+			rendered = styleNormal.Width(listWidth).Render(rendered)
+		}
+		rows = append(rows, rendered)
+	}
+
+	list := lipgloss.JoinVertical(lipgloss.Left, rows...)
+	preview := stylePreview.Width(previewWidth).Render(m.previewText(previewWidth - 2))
+	return lipgloss.JoinHorizontal(lipgloss.Top, list, "  ", preview)
+}
+
+func (m model) previewText(width int) string {
+	entry := m.selectedEntry()
+	if entry == nil {
+		return "No selection."
+	}
+	lines := []string{
+		styleTitle.Render("Focused snippet"),
+		entry.header(),
+		"",
+		wordWrap(entry.Snippet.Content, max(20, width)),
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderEntry(entry snippetEntry, selected bool) string {
+	headerStyle := styleLang
+	if selected {
+		headerStyle = styleAccent
+	}
+	header := headerStyle.Render(entry.header())
+	previewLine := firstLine(entry.Snippet.Content)
+	if previewLine == "" {
+		previewLine = "(empty snippet)"
+	}
+	return header + "\n" + previewLine
+}
+
+func (m model) selectedEntry() *snippetEntry {
+	if len(m.matches) == 0 || m.selected < 0 || m.selected >= len(m.matches) {
+		return nil
+	}
+	entry := &m.entries[m.matches[m.selected].Index]
+	return entry
+}
+
+type parsedArgs struct {
+	readmePath  string
+	jsonOut     bool
+	query       string
+	selectIndex int
+	action      string
+	help        bool
+}
+
+func parseArgs(argv []string) (parsedArgs, error) {
+	args := parsedArgs{
+		readmePath:  "README.md",
+		selectIndex: -1,
+		action:      "default",
+	}
+
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if !strings.HasPrefix(arg, "-") {
+			if args.readmePath != "README.md" {
+				return parsedArgs{}, fmt.Errorf("too many positional arguments")
+			}
+			args.readmePath = arg
+			continue
+		}
+
+		switch arg {
+		case "--json-out":
+			args.jsonOut = true
+		case "--help", "-h":
+			args.help = true
+		case "--query":
+			i++
+			if i >= len(argv) {
+				return parsedArgs{}, fmt.Errorf("--query requires a value")
+			}
+			args.query = argv[i]
+		case "--select-index":
+			i++
+			if i >= len(argv) {
+				return parsedArgs{}, fmt.Errorf("--select-index requires a value")
+			}
+			value, err := strconv.Atoi(argv[i])
+			if err != nil {
+				return parsedArgs{}, fmt.Errorf("invalid --select-index value: %w", err)
+			}
+			args.selectIndex = value
+		case "--action":
+			i++
+			if i >= len(argv) {
+				return parsedArgs{}, fmt.Errorf("--action requires a value")
+			}
+			args.action = argv[i]
+		default:
+			return parsedArgs{}, fmt.Errorf("unknown argument: %s", arg)
+		}
+	}
+
+	return args, nil
+}
+
+func main() {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	args, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if args.help {
+		fmt.Println("Usage: run-from-readme [README.md] [--query TEXT] [--json-out] [--select-index N] [--action default|as-is|escaped]")
+		return
+	}
+
+	if err := run(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}
+
+func run(args parsedArgs) error {
+	readmePath, err := filepath.Abs(args.readmePath)
+	if err != nil {
+		return err
+	}
+	markdown, err := os.ReadFile(readmePath)
+	if err != nil {
+		return err
+	}
+	snippets, err := parseShellSnippets(markdown)
+	if err != nil {
+		return err
+	}
+	if len(snippets) == 0 {
+		os.Exit(noMatchExitCode)
+	}
+
+	prefs, err := loadPreferences()
+	if err != nil {
+		return err
+	}
+	entries := make([]snippetEntry, len(snippets))
+	for i, s := range snippets {
+		entries[i] = snippetEntry{
+			Snippet:       s,
+			RememberedAsIs: prefs.RunAsIs[readmePath] != nil && prefs.RunAsIs[readmePath][s.key()],
+		}
+	}
+
+	if args.selectIndex >= 0 {
+		return emitNonInteractive(args, readmePath, entries, prefs)
+	}
+
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer tty.Close()
+
+	program := tea.NewProgram(newModel(readmePath, entries, args.query), tea.WithAltScreen(), tea.WithOutput(tty))
+	finalModel, err := program.Run()
+	if err != nil {
+		return err
+	}
+
+	if finalModel == nil {
+		return errors.New("bubble tea returned nil model")
+	}
+
+	m := finalModel.(model)
+	if !m.completed || m.action == nil {
+		os.Exit(noSelectionExitCode)
+	}
+	entry := m.selectedEntry()
+	if entry == nil {
+		os.Exit(noMatchExitCode)
+	}
+	output, updatedPrefs, err := resolveSelection(readmePath, m.matches[m.selected].Index, *entry, *m.action, prefs)
+	if err != nil {
+		return err
+	}
+	if err := savePreferences(updatedPrefs); err != nil {
+		return err
+	}
+	return writeSelection(output, args.jsonOut, os.Stdout)
+}
+
+func emitNonInteractive(args parsedArgs, readmePath string, entries []snippetEntry, prefs preferences) error {
+	filtered := filterEntries(entries, args.query)
+	if args.selectIndex < 0 || args.selectIndex >= len(filtered) {
+		return fmt.Errorf("select-index %d is out of range for %d matches", args.selectIndex, len(filtered))
+	}
+	act, err := parseAction(args.action)
+	if err != nil {
+		return err
+	}
+	index := filtered[args.selectIndex].Index
+	output, updatedPrefs, err := resolveSelection(readmePath, index, entries[index], act, prefs)
+	if err != nil {
+		return err
+	}
+	if err := savePreferences(updatedPrefs); err != nil {
+		return err
+	}
+	return writeSelection(output, args.jsonOut, os.Stdout)
+}
+
+func filterEntries(entries []snippetEntry, query string) []match {
+	if query == "" {
+		out := make([]match, len(entries))
+		for i := range entries {
+			out[i] = match{Index: i}
+		}
+		return out
+	}
+	pattern := fz.BuildPattern(query)
+	var matches []match
+	for i, entry := range entries {
+		text := strings.ToLower(entry.filterText())
+		if ok, positions := pattern.MatchItem(text); ok {
+			matches = append(matches, match{Index: i, Positions: positions})
+		}
+	}
+	return matches
+}
+
+func parseAction(raw string) (action, error) {
+	switch raw {
+	case "default":
+		return actionDefault, nil
+	case "as-is":
+		return actionRunAsIs, nil
+	case "escaped":
+		return actionRunEscaped, nil
+	default:
+		return actionDefault, fmt.Errorf("unknown action: %s", raw)
+	}
+}
+
+func resolveSelection(readmePath string, index int, entry snippetEntry, act action, prefs preferences) (selectionOutput, preferences, error) {
+	mode := entry.defaultRunMode()
+	switch act {
+	case actionRunAsIs:
+		mode = runModeAsIs
+	case actionRunEscaped:
+		if entry.Snippet.isNu() {
+			mode = runModeAsIs
+		} else {
+			mode = runModeEscaped
+		}
+	}
+
+	if act == actionRunAsIs && entry.Snippet.isShellLike() {
+		if prefs.RunAsIs == nil {
+			prefs.RunAsIs = map[string]map[string]bool{}
+		}
+		if prefs.RunAsIs[readmePath] == nil {
+			prefs.RunAsIs[readmePath] = map[string]bool{}
+		}
+		prefs.RunAsIs[readmePath][entry.Snippet.key()] = true
+		entry.RememberedAsIs = true
+	}
+
+	command := entry.Snippet.Content
+	if mode == runModeEscaped && entry.Snippet.isShellLike() {
+		command = escapeForNu(entry.Snippet.Content)
+	}
+	output := selectionOutput{
+		Index:          index,
+		Language:       entry.Snippet.Language,
+		Content:        entry.Snippet.Content,
+		RunMode:        mode,
+		Command:        command,
+		RememberedAsIs: entry.RememberedAsIs,
+	}
+	return output, prefs, nil
+}
+
+func writeSelection(output selectionOutput, jsonOut bool, w io.Writer) error {
+	if jsonOut {
+		return json.NewEncoder(w).Encode(output)
+	}
+	_, err := io.WriteString(w, output.Command)
+	return err
+}
+
+func parseShellSnippets(markdown []byte) ([]snippet, error) {
+	var snippets []snippet
+	lines := strings.Split(strings.ReplaceAll(string(markdown), "\r\n", "\n"), "\n")
+	inFence := false
+	fenceDelimiter := ""
+	language := ""
+	var content []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inFence {
+			if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+				delimiter := trimmed[:3]
+				rest := strings.TrimSpace(trimmed[3:])
+				fields := strings.Fields(rest)
+				lang := ""
+				if len(fields) > 0 {
+					lang = strings.ToLower(fields[0])
+				}
+				if !isShellLanguage(lang) {
+					inFence = true
+					fenceDelimiter = delimiter
+					language = ""
+					content = nil
+					continue
+				}
+				inFence = true
+				fenceDelimiter = delimiter
+				language = lang
+				content = nil
+			}
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, fenceDelimiter) {
+			if language != "" {
+				snippets = append(snippets, snippet{
+					Language: language,
+					Content:  strings.Join(content, "\n"),
+				})
+			}
+			inFence = false
+			fenceDelimiter = ""
+			language = ""
+			content = nil
+			continue
+		}
+
+		if language != "" {
+			content = append(content, line)
+		}
+	}
+	return snippets, nil
+}
+
+func isShellLanguage(lang string) bool {
+	switch lang {
+	case "shell", "bash", "sh", "nushell":
+		return true
+	default:
+		return false
+	}
+}
+
+func escapeForNu(content string) string {
+	maxHashes := 0
+	runes := []rune(content)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '\'' {
+			continue
+		}
+		hashes := 0
+		for j := i + 1; j < len(runes) && runes[j] == '#'; j++ {
+			hashes++
+		}
+		maxHashes = max(maxHashes, hashes)
+	}
+	repeated := strings.Repeat("#", maxHashes+1)
+	return fmt.Sprintf("bash -c (r%s'\n%s\n'%s | str substring 1..-2)", repeated, content, repeated)
+}
+
+func firstLine(content string) string {
+	line, _, _ := strings.Cut(content, "\n")
+	return line
+}
+
+func wordWrap(input string, width int) string {
+	if width <= 0 {
+		return input
+	}
+	lines := strings.Split(input, "\n")
+	var wrapped []string
+	for _, line := range lines {
+		if lipgloss.Width(line) <= width {
+			wrapped = append(wrapped, line)
+			continue
+		}
+		var current bytes.Buffer
+		for _, word := range strings.Fields(line) {
+			next := word
+			if current.Len() > 0 {
+				next = current.String() + " " + word
+			}
+			if lipgloss.Width(next) > width && current.Len() > 0 {
+				wrapped = append(wrapped, current.String())
+				current.Reset()
+				current.WriteString(word)
+			} else {
+				if current.Len() > 0 {
+					current.WriteByte(' ')
+				}
+				current.WriteString(word)
+			}
+		}
+		if current.Len() == 0 {
+			wrapped = append(wrapped, line)
+		} else {
+			wrapped = append(wrapped, current.String())
+		}
+	}
+	return strings.Join(wrapped, "\n")
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func init() {
+	styleSelected = styleSelected.MaxWidth(80)
+	styleNormal = styleNormal.MaxWidth(80)
+	stylePreview = stylePreview.MaxWidth(80)
+}
+

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -98,21 +114,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -122,7 +171,25 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -157,10 +224,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -189,7 +277,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -228,6 +316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +364,25 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -302,6 +421,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "run-from-readme"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "pulldown-cmark",
+ "ratatui",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -379,6 +536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +577,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "static_assertions"
@@ -460,7 +635,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -473,6 +657,23 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -510,10 +711,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -434,10 +434,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "run-from-readme"
+name = "run-from-readme-rs"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "my-fuzzy-finder-lib",
  "pulldown-cmark",
  "ratatui",
  "rusqlite",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "my-fuzzy-finder",
-    "my-fuzzy-finder-lib", "run-from-readme",
+    "my-fuzzy-finder-lib",
+    "run-from-readme",
 ]
 resolver = "2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
     "my-fuzzy-finder",
-    "my-fuzzy-finder-lib",
+    "my-fuzzy-finder-lib", "run-from-readme",
 ]
 resolver = "2"

--- a/rust/README.md
+++ b/rust/README.md
@@ -5,7 +5,8 @@ Rust code that supports my personal workflows.
 
 ## Overview
 
-This directory contains an experimental Rust implementation of `my-fuzzy-finder` and its matching library.
+This directory contains an experimental Rust implementation of `my-fuzzy-finder`, a new `run-from-readme-rs`
+prototype, and the matching library they share.
 
 I implemented this with Cursor and cloud agents. The interactive behavior was validated in Cursor Cloud with manual
 computer-use sessions and screen/video capture.
@@ -19,6 +20,12 @@ An experimental Rust commandline fuzzy finder with a JSON API. The compiled bina
 ### `my-fuzzy-finder-lib/`
 
 An experimental Rust library containing the fzf-inspired matching logic used by `my-fuzzy-finder`.
+
+
+### `run-from-readme/`
+
+A Rust TUI prototype for selecting shell snippets from a README and emitting either the escaped Nushell command or the
+raw snippet directly.
 
 
 ## Dependency Notes
@@ -64,13 +71,20 @@ Follow these instructions to build, run and install the Rust code.
    * ```json
      {"index": 1, "value": "Dear reader,\nHello.\nSincerely, writer"}
      ```
-4. Build the executable:
+4. Build and run the `run-from-readme-rs` prototype:
+   * ```nushell
+     do run run-from-readme ../mac-os/README.md
+     ```
+   * Use `Enter` to run the selected snippet with its default mode.
+   * Use `Shift+Enter` when your terminal reports that key combination, or `F2` as a fallback, to run a shell snippet
+     as-is and remember that choice for future sessions.
+5. Build the executables:
    * ```nushell
      do build
      ```
-   * The executable will be copied to `bin/my-fuzzy-finder-rs`.
-5. Install the executable:
+   * The executables will be copied to `bin/my-fuzzy-finder-rs` and `bin/run-from-readme-rs`.
+6. Install the executables:
    * ```nushell
      do install
      ```
-   * This uses `cargo install --path my-fuzzy-finder --force` and installs the `my-fuzzy-finder-rs` binary.
+   * This installs both `my-fuzzy-finder-rs` and `run-from-readme-rs`.

--- a/rust/do.nu
+++ b/rust/do.nu
@@ -15,11 +15,23 @@ export def --wrapped "run my-fuzzy-finder" [...args] {
     }
 }
 
+export def --wrapped "run run-from-readme" [...args] {
+    let _in = $in
+    cd $DIR
+    if ($_in | is-empty) {
+        cargo run --quiet --package run-from-readme-rs -- ...$args
+    } else {
+        $_in | (cargo run --quiet --package run-from-readme-rs -- ...$args)
+    }
+}
+
 export def build [] {
     cd $DIR
     mkdir bin
     cargo build --release --package my-fuzzy-finder-rs
     cp target/release/my-fuzzy-finder-rs bin/my-fuzzy-finder-rs
+    cargo build --release --package run-from-readme-rs
+    cp target/release/run-from-readme-rs bin/run-from-readme-rs
 }
 
 export def install [] {

--- a/rust/run-from-readme/Cargo.toml
+++ b/rust/run-from-readme/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "run-from-readme-rs"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "run-from-readme-rs"
+path = "src/main.rs"
+
+[dependencies]
+crossterm = { version = "0.28.1", features = ["use-dev-tty"] }
+my-fuzzy-finder-lib = { path = "../my-fuzzy-finder-lib" }
+pulldown-cmark = "0.13.3"
+ratatui = "0.28.1"
+rusqlite = { version = "0.39.0", features = ["bundled"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+unicode-width = "0.2.2"

--- a/rust/run-from-readme/src/main.rs
+++ b/rust/run-from-readme/src/main.rs
@@ -1,0 +1,1058 @@
+use std::collections::{HashSet, hash_map::DefaultHasher};
+use std::env;
+use std::fmt::{self, Display};
+use std::fs::{self, File, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyModifiers, KeyboardEnhancementFlags,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use my_fuzzy_finder_lib as matcher;
+use pulldown_cmark::{CodeBlockKind, Event as MarkdownEvent, Options, Parser, Tag, TagEnd};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Margin};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Paragraph, Wrap};
+use rusqlite::{Connection, params};
+use serde::Serialize;
+use unicode_width::UnicodeWidthChar;
+
+const NO_MATCH_EXIT_CODE: i32 = 1;
+const NO_SELECTION_EXIT_CODE: i32 = 130;
+const QUERY_CHAR_LIMIT: usize = 64;
+const ACCENT_COLOR: Color = Color::Rgb(0xDA, 0x5C, 0xE4);
+const PROMPT: &str = "Filter: ";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum RunMode {
+    Escaped,
+    AsIs,
+}
+
+impl Display for RunMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RunMode::Escaped => write!(f, "escaped"),
+            RunMode::AsIs => write!(f, "as-is"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Action {
+    Default,
+    ForceAsIs,
+    ForceEscaped,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct ShellSnippet {
+    language: String,
+    content: String,
+}
+
+impl ShellSnippet {
+    fn is_nushell(&self) -> bool {
+        self.language == "nushell"
+    }
+
+    fn is_shell_like(&self) -> bool {
+        matches!(self.language.as_str(), "shell" | "bash" | "sh")
+    }
+
+    fn key(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.language.hash(&mut hasher);
+        self.content.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SnippetEntry {
+    snippet: ShellSnippet,
+    remembered_as_is: bool,
+}
+
+impl SnippetEntry {
+    fn default_run_mode(&self) -> RunMode {
+        if self.snippet.is_nushell() || self.remembered_as_is {
+            RunMode::AsIs
+        } else {
+            RunMode::Escaped
+        }
+    }
+
+    fn filter_text(&self) -> String {
+        format!(
+            "{}[{}] [default: {}{}]\n{}",
+            if self.remembered_as_is { "✓ " } else { "" },
+            self.snippet.language,
+            self.default_run_mode(),
+            if self.remembered_as_is {
+                ", remembered"
+            } else {
+                ""
+            },
+            self.snippet.content
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Match {
+    index: usize,
+    positions: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct App {
+    entries: Vec<SnippetEntry>,
+    filter_texts: Vec<String>,
+    query: String,
+    matches: Vec<Match>,
+    pages: Vec<Vec<Match>>,
+    item: Option<usize>,
+    page: usize,
+    page_item: usize,
+    selection_action: Option<Action>,
+    keyboard_enhancement_enabled: bool,
+}
+
+impl App {
+    fn new(entries: Vec<SnippetEntry>, query: String, keyboard_enhancement_enabled: bool) -> Self {
+        let filter_texts = entries.iter().map(SnippetEntry::filter_text).collect();
+        Self {
+            entries,
+            filter_texts,
+            query,
+            matches: Vec::new(),
+            pages: Vec::new(),
+            item: None,
+            page: 0,
+            page_item: 0,
+            selection_action: None,
+            keyboard_enhancement_enabled,
+        }
+    }
+
+    fn selected_entry(&self) -> Option<&SnippetEntry> {
+        self.item.and_then(|index| self.entries.get(index))
+    }
+
+    fn render(&self, frame: &mut ratatui::Frame<'_>) {
+        let area = if frame.area().height > 12 && frame.area().width > 70 {
+            frame.area().inner(Margin {
+                vertical: 1,
+                horizontal: 2,
+            })
+        } else {
+            frame.area()
+        };
+
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let sections = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(2),
+                Constraint::Min(1),
+            ])
+            .split(area);
+
+        let cursor = Span::styled("█", Style::default().fg(ACCENT_COLOR));
+        let input = Paragraph::new(Line::from(vec![
+            Span::styled(PROMPT, Style::default().fg(Color::DarkGray)),
+            Span::raw(self.query.clone()),
+            cursor,
+        ]));
+        frame.render_widget(input, sections[0]);
+
+        let selected_entry = self.selected_entry();
+        let help_line_1 = Line::from(vec![
+            Span::styled("Enter", Style::default().fg(ACCENT_COLOR)),
+            Span::raw(": run default   "),
+            Span::styled(
+                if self.keyboard_enhancement_enabled {
+                    "Shift+Enter"
+                } else {
+                    "Shift+Enter/F2"
+                },
+                Style::default().fg(ACCENT_COLOR),
+            ),
+            Span::raw(": run as-is   "),
+            Span::styled("Esc", Style::default().fg(ACCENT_COLOR)),
+            Span::raw(": cancel"),
+        ]);
+        let help_line_2 = Line::from(vec![
+            Span::raw("Selected default: "),
+            Span::styled(
+                selected_entry
+                    .map(|entry| entry.default_run_mode().to_string())
+                    .unwrap_or_else(|| "n/a".to_string()),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::raw("   [default: as-is, remembered] means Enter reuses your earlier choice"),
+        ]);
+        frame.render_widget(Paragraph::new(Text::from(vec![help_line_1, help_line_2])), sections[1]);
+
+        let content = if self.pages.is_empty() {
+            Text::from(Line::from(Span::styled(
+                "No matches.",
+                Style::default().fg(Color::DarkGray),
+            )))
+        } else {
+            let page = &self.pages[self.page];
+            let text_width = sections[2].width.saturating_sub(2).max(1);
+            let mut lines = Vec::new();
+
+            for (index, item_match) in page.iter().enumerate() {
+                let selected = index == self.page_item;
+                lines.extend(render_item(
+                    &self.filter_texts[item_match.index],
+                    &item_match.positions,
+                    selected,
+                    text_width,
+                ));
+            }
+
+            Text::from(lines)
+        };
+
+        let content = Paragraph::new(content).wrap(Wrap { trim: false });
+        frame.render_widget(content, sections[2]);
+    }
+
+    fn refresh_matches(&mut self, height: u16, width: u16) {
+        if self.query.is_empty() {
+            self.matches.clear();
+        } else {
+            self.matches = match_all(&self.query, &self.filter_texts);
+        }
+        self.reflow(height, width);
+    }
+
+    fn reflow(&mut self, height: u16, width: u16) {
+        if self.entries.is_empty() {
+            self.pages.clear();
+            self.item = None;
+            self.page = 0;
+            self.page_item = 0;
+            return;
+        }
+
+        let matches = if self.query.is_empty() {
+            self.filter_texts
+                .iter()
+                .enumerate()
+                .map(|(index, _)| Match {
+                    index,
+                    positions: Vec::new(),
+                })
+                .collect::<Vec<_>>()
+        } else if self.matches.is_empty() {
+            self.pages.clear();
+            self.item = None;
+            self.page = 0;
+            self.page_item = 0;
+            return;
+        } else {
+            self.matches.clone()
+        };
+
+        let use_margin = height > 12 && width > 70;
+        let inner_height = if use_margin {
+            height.saturating_sub(2)
+        } else {
+            height
+        };
+        let inner_width = if use_margin {
+            width.saturating_sub(4)
+        } else {
+            width
+        };
+        let available_height = inner_height.saturating_sub(3).max(1) as usize;
+        let available_width = inner_width.saturating_sub(2).max(1) as usize;
+
+        let previous_item = self.item.unwrap_or(0);
+        let mut closest_distance = self.entries.len();
+        let mut pages: Vec<Vec<Match>> = Vec::new();
+        let mut page: Vec<Match> = Vec::new();
+        let mut height_budget = available_height;
+        let mut new_selected_item = None;
+        let mut new_selected_page = 0usize;
+        let mut new_selected_page_item = 0usize;
+
+        for item_match in matches {
+            let item_height = wrapped_height(&self.filter_texts[item_match.index], available_width);
+            if item_height > height_budget && !page.is_empty() {
+                pages.push(std::mem::take(&mut page));
+                height_budget = available_height;
+            }
+
+            page.push(item_match.clone());
+            height_budget = height_budget.saturating_sub(item_height.max(1));
+
+            let distance = previous_item.abs_diff(item_match.index);
+            if distance < closest_distance {
+                new_selected_item = Some(item_match.index);
+                new_selected_page = pages.len();
+                new_selected_page_item = page.len() - 1;
+                closest_distance = distance;
+            }
+        }
+
+        if !page.is_empty() {
+            pages.push(page);
+        }
+
+        self.pages = pages;
+        self.item = new_selected_item;
+        self.page = new_selected_page.min(self.pages.len().saturating_sub(1));
+        self.page_item = new_selected_page_item;
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, height: u16, width: u16) -> bool {
+        if key.kind != event::KeyEventKind::Press {
+            return false;
+        }
+
+        match key.code {
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => true,
+            KeyCode::Esc => true,
+            KeyCode::F(2) => {
+                self.selection_action = Some(Action::ForceAsIs);
+                true
+            }
+            KeyCode::Enter => {
+                self.selection_action = Some(if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    Action::ForceAsIs
+                } else {
+                    Action::Default
+                });
+                true
+            }
+            KeyCode::Up => {
+                if self.item.is_none() || self.pages.is_empty() {
+                    return false;
+                }
+
+                if self.page_item == 0 {
+                    if self.page == 0 {
+                        return false;
+                    }
+
+                    self.page -= 1;
+                    self.page_item = self.pages[self.page].len() - 1;
+                } else {
+                    self.page_item -= 1;
+                }
+
+                self.item = Some(self.pages[self.page][self.page_item].index);
+                false
+            }
+            KeyCode::Down => {
+                if self.item.is_none() || self.pages.is_empty() {
+                    return false;
+                }
+
+                if self.page_item + 1 >= self.pages[self.page].len() {
+                    if self.page + 1 >= self.pages.len() {
+                        return false;
+                    }
+
+                    self.page += 1;
+                    self.page_item = 0;
+                } else {
+                    self.page_item += 1;
+                }
+
+                self.item = Some(self.pages[self.page][self.page_item].index);
+                false
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.refresh_matches(height, width);
+                false
+            }
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                if self.query.chars().count() >= QUERY_CHAR_LIMIT {
+                    return false;
+                }
+
+                self.query.push(ch);
+                self.refresh_matches(height, width);
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ParsedArgs {
+    readme_path: PathBuf,
+    json_out: bool,
+    initial_query: String,
+    select_index: Option<usize>,
+    action: Option<Action>,
+    show_help: bool,
+}
+
+#[derive(Serialize)]
+struct SelectionOutput<'a> {
+    index: usize,
+    language: &'a str,
+    content: &'a str,
+    run_mode: RunMode,
+    command: String,
+    remembered_as_is: bool,
+}
+
+struct TerminalGuard {
+    terminal: Terminal<CrosstermBackend<File>>,
+    keyboard_enhancement_enabled: bool,
+}
+
+impl TerminalGuard {
+    fn new(tty: File) -> io::Result<Self> {
+        enable_raw_mode()?;
+        let backend = CrosstermBackend::new(tty);
+        let mut terminal = Terminal::new(backend)?;
+        let keyboard_enhancement_enabled = execute!(
+            terminal.backend_mut(),
+            EnterAlternateScreen,
+            Hide,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
+        )
+        .is_ok();
+        if !keyboard_enhancement_enabled {
+            execute!(terminal.backend_mut(), EnterAlternateScreen, Hide)?;
+        }
+        terminal.clear()?;
+        Ok(Self {
+            terminal,
+            keyboard_enhancement_enabled,
+        })
+    }
+
+    fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<File>> {
+        &mut self.terminal
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        if self.keyboard_enhancement_enabled {
+            let _ = execute!(
+                self.terminal.backend_mut(),
+                PopKeyboardEnhancementFlags,
+                Show,
+                LeaveAlternateScreen
+            );
+        } else {
+            let _ = execute!(self.terminal.backend_mut(), Show, LeaveAlternateScreen);
+        }
+    }
+}
+
+struct PreferenceStore {
+    connection: Connection,
+}
+
+impl PreferenceStore {
+    fn open() -> Result<Self, Box<dyn std::error::Error>> {
+        let home = env::var_os("HOME").ok_or("HOME is not set")?;
+        let directory = PathBuf::from(home).join(".run-from-readme-rs");
+        fs::create_dir_all(&directory)?;
+        let database_path = directory.join("preferences.sqlite3");
+        let connection = Connection::open(database_path)?;
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS snippet_preferences (
+                readme_path TEXT NOT NULL,
+                snippet_key TEXT NOT NULL,
+                run_as_is INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (readme_path, snippet_key)
+            )",
+            [],
+        )?;
+        Ok(Self { connection })
+    }
+
+    fn remembered_keys(
+        &self,
+        readme_path: &str,
+    ) -> Result<HashSet<String>, Box<dyn std::error::Error>> {
+        let mut statement = self.connection.prepare(
+            "SELECT snippet_key
+             FROM snippet_preferences
+             WHERE readme_path = ?1 AND run_as_is = 1",
+        )?;
+        let rows = statement.query_map([readme_path], |row| row.get::<_, String>(0))?;
+        let mut keys = HashSet::new();
+        for row in rows {
+            keys.insert(row?);
+        }
+        Ok(keys)
+    }
+
+    fn remember_as_is(
+        &self,
+        readme_path: &str,
+        snippet_key: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.connection.execute(
+            "INSERT INTO snippet_preferences (readme_path, snippet_key, run_as_is)
+             VALUES (?1, ?2, 1)
+             ON CONFLICT(readme_path, snippet_key)
+             DO UPDATE SET run_as_is = excluded.run_as_is",
+            params![readme_path, snippet_key],
+        )?;
+        Ok(())
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(code) => std::process::exit(code),
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<i32, Box<dyn std::error::Error>> {
+    let args = parse_args(env::args().skip(1).collect())?;
+    if args.show_help {
+        return Ok(0);
+    }
+
+    let readme_path = normalize_readme_path(&args.readme_path)?;
+    let readme_path_string = readme_path.to_string_lossy().into_owned();
+    let markdown = fs::read_to_string(&readme_path)?;
+    let snippets = parse_shell_snippets(&markdown);
+    if snippets.is_empty() {
+        eprintln!("No shell snippets found in {}.", readme_path.display());
+        return Ok(NO_MATCH_EXIT_CODE);
+    }
+
+    let store = PreferenceStore::open()?;
+    let remembered_keys = store.remembered_keys(&readme_path_string)?;
+    let entries = snippets
+        .into_iter()
+        .map(|snippet| {
+            let remembered_as_is = remembered_keys.contains(&snippet.key());
+            SnippetEntry {
+                snippet,
+                remembered_as_is,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(select_index) = args.select_index {
+        return run_non_interactive(entries, select_index, &args, &store, &readme_path_string);
+    }
+
+    let tty = OpenOptions::new().read(true).write(true).open("/dev/tty")?;
+    let mut terminal = TerminalGuard::new(tty.try_clone()?)?;
+    let initial_area = terminal.terminal_mut().size()?;
+    let mut app = App::new(
+        entries,
+        args.initial_query.clone(),
+        terminal.keyboard_enhancement_enabled,
+    );
+    app.refresh_matches(initial_area.height, initial_area.width);
+
+    loop {
+        let size = terminal.terminal_mut().size()?;
+        app.reflow(size.height, size.width);
+        terminal.terminal_mut().draw(|frame| app.render(frame))?;
+
+        if event::poll(Duration::from_millis(250))? {
+            match event::read()? {
+                Event::Key(key) => {
+                    if app.handle_key(key, size.height, size.width) {
+                        break;
+                    }
+                }
+                Event::Resize(width, height) => {
+                    app.reflow(height, width);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    drop(terminal);
+
+    let Some(action) = app.selection_action else {
+        return Ok(NO_SELECTION_EXIT_CODE);
+    };
+    let Some(index) = app.item else {
+        return Ok(NO_MATCH_EXIT_CODE);
+    };
+    let entry = app.selected_entry().expect("selected entry must exist");
+    emit_selection(index, entry, action, args.json_out, &store, &readme_path_string)?;
+    Ok(0)
+}
+
+fn run_non_interactive(
+    entries: Vec<SnippetEntry>,
+    select_index: usize,
+    args: &ParsedArgs,
+    store: &PreferenceStore,
+    readme_path: &str,
+) -> Result<i32, Box<dyn std::error::Error>> {
+    let filtered_indices = filter_indices(&args.initial_query, &entries);
+    let Some(entry_index) = filtered_indices.get(select_index).copied() else {
+        return Err(format!(
+            "select-index {} is out of range for {} matches",
+            select_index,
+            filtered_indices.len()
+        )
+        .into());
+    };
+    let action = args.action.unwrap_or(Action::Default);
+    let entry = &entries[entry_index];
+    emit_selection(entry_index, entry, action, args.json_out, store, readme_path)?;
+    Ok(0)
+}
+
+fn emit_selection(
+    index: usize,
+    entry: &SnippetEntry,
+    action: Action,
+    json_out: bool,
+    store: &PreferenceStore,
+    readme_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let run_mode = resolve_run_mode(entry, action);
+    let remembered_as_is = entry.remembered_as_is
+        || (run_mode == RunMode::AsIs && entry.snippet.is_shell_like() && action == Action::ForceAsIs);
+    if run_mode == RunMode::AsIs && entry.snippet.is_shell_like() && action == Action::ForceAsIs {
+        store.remember_as_is(readme_path, &entry.snippet.key())?;
+    }
+
+    let command = build_command(&entry.snippet, run_mode);
+    let selection = SelectionOutput {
+        index,
+        language: &entry.snippet.language,
+        content: &entry.snippet.content,
+        run_mode,
+        command,
+        remembered_as_is,
+    };
+
+    if json_out {
+        serde_json::to_writer(io::stdout(), &selection)?;
+        println!();
+    } else {
+        print!("{}", selection.command);
+    }
+    Ok(())
+}
+
+fn parse_args(args: Vec<String>) -> Result<ParsedArgs, Box<dyn std::error::Error>> {
+    let mut parsed = ParsedArgs {
+        readme_path: PathBuf::from("README.md"),
+        json_out: false,
+        initial_query: String::new(),
+        select_index: None,
+        action: None,
+        show_help: false,
+    };
+    let mut positionals = Vec::new();
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--json-out" => parsed.json_out = true,
+            "--query" => {
+                parsed.initial_query = iter.next().ok_or("--query requires a value")?;
+            }
+            "--select-index" => {
+                let value = iter.next().ok_or("--select-index requires a value")?;
+                parsed.select_index = Some(value.parse()?);
+            }
+            "--action" => {
+                let value = iter.next().ok_or("--action requires a value")?;
+                parsed.action = Some(parse_action(&value)?);
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: run-from-readme-rs [README.md] [--json-out] [--query TEXT] [--select-index N] [--action default|as-is|escaped]"
+                );
+                parsed.show_help = true;
+            }
+            _ if arg.starts_with("--") => return Err(format!("unknown argument: {arg}").into()),
+            _ => positionals.push(arg),
+        }
+    }
+
+    if positionals.len() > 1 {
+        return Err("too many positional arguments".into());
+    }
+    if let Some(path) = positionals.into_iter().next() {
+        parsed.readme_path = PathBuf::from(path);
+    }
+
+    Ok(parsed)
+}
+
+fn parse_action(value: &str) -> Result<Action, Box<dyn std::error::Error>> {
+    match value {
+        "default" => Ok(Action::Default),
+        "as-is" => Ok(Action::ForceAsIs),
+        "escaped" => Ok(Action::ForceEscaped),
+        _ => Err(format!("unknown action: {value}").into()),
+    }
+}
+
+fn normalize_readme_path(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if path.exists() {
+        Ok(path.canonicalize()?)
+    } else {
+        Err(format!("README file not found: {}", path.display()).into())
+    }
+}
+
+fn parse_shell_snippets(markdown: &str) -> Vec<ShellSnippet> {
+    let parser = Parser::new_ext(markdown, Options::all());
+    let mut snippets = Vec::new();
+    let mut current_language = None;
+    let mut current_content = String::new();
+    let mut in_code_block = false;
+
+    for event in parser {
+        match event {
+            MarkdownEvent::Start(Tag::CodeBlock(kind)) => {
+                in_code_block = true;
+                current_content.clear();
+                current_language = match kind {
+                    CodeBlockKind::Fenced(language) => {
+                        let normalized = language
+                            .split_whitespace()
+                            .next()
+                            .unwrap_or("")
+                            .trim()
+                            .to_ascii_lowercase();
+                        if normalized.is_empty() {
+                            None
+                        } else {
+                            Some(normalized)
+                        }
+                    }
+                    CodeBlockKind::Indented => None,
+                };
+            }
+            MarkdownEvent::Text(text) if in_code_block => current_content.push_str(&text),
+            MarkdownEvent::SoftBreak if in_code_block => current_content.push('\n'),
+            MarkdownEvent::HardBreak if in_code_block => current_content.push('\n'),
+            MarkdownEvent::End(TagEnd::CodeBlock) => {
+                in_code_block = false;
+                remove_one_trailing_line_ending(&mut current_content);
+                if let Some(language) = current_language.take() {
+                    if matches!(language.as_str(), "shell" | "bash" | "sh" | "nushell") {
+                        snippets.push(ShellSnippet {
+                            language,
+                            content: current_content.clone(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    snippets
+}
+
+fn remove_one_trailing_line_ending(content: &mut String) {
+    if content.ends_with("\r\n") {
+        content.truncate(content.len() - 2);
+    } else if content.ends_with('\n') {
+        content.pop();
+    }
+}
+
+fn filter_indices(query: &str, entries: &[SnippetEntry]) -> Vec<usize> {
+    if query.is_empty() {
+        return (0..entries.len()).collect();
+    }
+
+    let filter_texts = entries.iter().map(SnippetEntry::filter_text).collect::<Vec<_>>();
+    match_all(query, &filter_texts)
+        .into_iter()
+        .map(|item_match| item_match.index)
+        .collect()
+}
+
+fn resolve_run_mode(entry: &SnippetEntry, action: Action) -> RunMode {
+    match action {
+        Action::Default => entry.default_run_mode(),
+        Action::ForceAsIs => RunMode::AsIs,
+        Action::ForceEscaped => {
+            if entry.snippet.is_nushell() {
+                RunMode::AsIs
+            } else {
+                RunMode::Escaped
+            }
+        }
+    }
+}
+
+fn build_command(snippet: &ShellSnippet, run_mode: RunMode) -> String {
+    if run_mode == RunMode::AsIs || snippet.is_nushell() {
+        return snippet.content.clone();
+    }
+
+    let max_hash_count = max_hash_count_after_apostrophe(&snippet.content);
+    let repetitive_hashtags = "#".repeat(max_hash_count + 1);
+    format!(
+        "bash -c (r{hashtags}'\n{content}\n'{hashtags} | str substring 1..-2)",
+        hashtags = repetitive_hashtags,
+        content = snippet.content
+    )
+}
+
+fn max_hash_count_after_apostrophe(content: &str) -> usize {
+    let chars = content.chars().collect::<Vec<_>>();
+    let mut max_hash_count = 0usize;
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        if chars[index] == '\'' {
+            let mut hash_count = 0usize;
+            let mut cursor = index + 1;
+            while cursor < chars.len() && chars[cursor] == '#' {
+                hash_count += 1;
+                cursor += 1;
+            }
+            max_hash_count = max_hash_count.max(hash_count);
+        }
+        index += 1;
+    }
+
+    max_hash_count
+}
+
+fn match_all(query: &str, items: &[String]) -> Vec<Match> {
+    items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            matcher::matches(query, item).map(|positions| Match { index, positions })
+        })
+        .collect()
+}
+
+fn render_item(
+    item: &str,
+    matched_positions: &[usize],
+    selected: bool,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let matched_positions = matched_positions.iter().copied().collect::<HashSet<_>>();
+    let base_style = if selected {
+        Style::default().fg(ACCENT_COLOR)
+    } else {
+        Style::default()
+    };
+    let prefix = if selected { "│ " } else { "  " };
+    let prefix_style = if selected {
+        Style::default().fg(ACCENT_COLOR)
+    } else {
+        Style::default()
+    };
+
+    let mut current_line = vec![Span::styled(prefix.to_string(), prefix_style)];
+    let mut current_group = String::new();
+    let mut current_style = base_style;
+
+    for (index, ch) in item.chars().enumerate() {
+        if ch == '\n' {
+            flush_group(&mut current_line, &mut current_group, current_style);
+            lines.push(Line::from(current_line));
+            current_line = vec![Span::styled(prefix.to_string(), prefix_style)];
+            current_style = base_style;
+            continue;
+        }
+
+        let matched = matched_positions.contains(&index);
+        let style = if matched {
+            base_style.add_modifier(Modifier::UNDERLINED)
+        } else {
+            base_style
+        };
+
+        if style != current_style && !current_group.is_empty() {
+            flush_group(&mut current_line, &mut current_group, current_style);
+        }
+
+        current_style = style;
+        current_group.push(ch);
+    }
+
+    flush_group(&mut current_line, &mut current_group, current_style);
+    lines.push(Line::from(current_line));
+
+    let max_width = width.max(1) as usize;
+    let mut wrapped = Vec::new();
+    for line in lines {
+        wrapped.extend(wrap_line(line, max_width));
+    }
+    wrapped
+}
+
+fn flush_group(line: &mut Vec<Span<'static>>, group: &mut String, style: Style) {
+    if !group.is_empty() {
+        line.push(Span::styled(std::mem::take(group), style));
+    }
+}
+
+fn wrap_line(line: Line<'static>, width: usize) -> Vec<Line<'static>> {
+    if width == 0 {
+        return vec![line];
+    }
+
+    let mut result = Vec::new();
+    let spans = line.spans;
+    let mut current = Vec::new();
+    let mut current_width = 0usize;
+
+    for span in spans {
+        let content = span.content.to_string();
+        let style = span.style;
+        let mut piece = String::new();
+
+        for ch in content.chars() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0).max(1);
+            if current_width + ch_width > width && !piece.is_empty() {
+                current.push(Span::styled(std::mem::take(&mut piece), style));
+                result.push(Line::from(std::mem::take(&mut current)));
+                current_width = 0;
+            }
+
+            piece.push(ch);
+            current_width += ch_width;
+        }
+
+        if !piece.is_empty() {
+            current.push(Span::styled(piece, style));
+        }
+    }
+
+    if current.is_empty() {
+        result.push(Line::default());
+    } else {
+        result.push(Line::from(current));
+    }
+
+    result
+}
+
+fn wrapped_height(item: &str, width: usize) -> usize {
+    let width = width.max(1);
+    item.split('\n')
+        .map(|line| {
+            let display_width = line
+                .chars()
+                .map(|ch| UnicodeWidthChar::width(ch).unwrap_or(0))
+                .sum::<usize>();
+            display_width.max(1).div_ceil(width)
+        })
+        .sum::<usize>()
+        .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_shell_snippets_from_markdown() {
+        let markdown = r#"
+# demo
+
+```bash
+echo bash
+```
+
+```python
+print("ignored")
+```
+
+```nushell
+ls
+```
+"#;
+
+        let snippets = parse_shell_snippets(markdown);
+        assert_eq!(snippets.len(), 2);
+        assert_eq!(snippets[0].language, "bash");
+        assert_eq!(snippets[0].content, "echo bash");
+        assert_eq!(snippets[1].language, "nushell");
+        assert_eq!(snippets[1].content, "ls");
+    }
+
+    #[test]
+    fn escapes_shell_content_for_nushell_bash_invocation() {
+        let snippet = ShellSnippet {
+            language: "bash".to_string(),
+            content: "printf \"hello\"\nr###'unsafe'###".to_string(),
+        };
+
+        let command = build_command(&snippet, RunMode::Escaped);
+        assert!(command.starts_with("bash -c (r####'"));
+        assert!(command.contains("printf \"hello\""));
+        assert!(command.ends_with("'#### | str substring 1..-2)"));
+    }
+
+    #[test]
+    fn remembered_shell_snippets_default_to_as_is() {
+        let entry = SnippetEntry {
+            snippet: ShellSnippet {
+                language: "bash".to_string(),
+                content: "cargo test".to_string(),
+            },
+            remembered_as_is: true,
+        };
+
+        assert_eq!(entry.default_run_mode(), RunMode::AsIs);
+        assert_eq!(resolve_run_mode(&entry, Action::Default), RunMode::AsIs);
+    }
+
+    #[test]
+    fn forcing_escaped_does_not_change_nushell_behavior() {
+        let entry = SnippetEntry {
+            snippet: ShellSnippet {
+                language: "nushell".to_string(),
+                content: "ls".to_string(),
+            },
+            remembered_as_is: false,
+        };
+
+        assert_eq!(resolve_run_mode(&entry, Action::ForceEscaped), RunMode::AsIs);
+    }
+}

--- a/rust/run-from-readme/src/main.rs
+++ b/rust/run-from-readme/src/main.rs
@@ -98,7 +98,11 @@ impl SnippetEntry {
     fn filter_text(&self) -> String {
         format!(
             "{}[{}] [default: {}{}]\n{}",
-            if self.remembered_as_is { "✓ " } else { "" },
+            if self.remembered_as_is {
+                "[saved] "
+            } else {
+                ""
+            },
             self.snippet.language,
             self.default_run_mode(),
             if self.remembered_as_is {
@@ -209,7 +213,7 @@ impl App {
                     .unwrap_or_else(|| "n/a".to_string()),
                 Style::default().fg(Color::Yellow),
             ),
-            Span::raw("   [default: as-is, remembered] means Enter reuses your earlier choice"),
+            Span::raw("   [saved] marks snippets whose default Enter action is remembered"),
         ]);
         frame.render_widget(Paragraph::new(Text::from(vec![help_line_1, help_line_2])), sections[1]);
 

--- a/rust/run-from-readme/src/main.rs
+++ b/rust/run-from-readme/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fmt::{self, Display};
 use std::fs::{self, File, OpenOptions};
 use std::hash::{Hash, Hasher};
-use std::io::{self, Read};
+use std::io::{self};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -196,6 +196,8 @@ impl App {
                 Style::default().fg(ACCENT_COLOR),
             ),
             Span::raw(": run as-is   "),
+            Span::styled("F3", Style::default().fg(ACCENT_COLOR)),
+            Span::raw(": run escaped   "),
             Span::styled("Esc", Style::default().fg(ACCENT_COLOR)),
             Span::raw(": cancel"),
         ]);
@@ -337,6 +339,10 @@ impl App {
             KeyCode::Esc => true,
             KeyCode::F(2) => {
                 self.selection_action = Some(Action::ForceAsIs);
+                true
+            }
+            KeyCode::F(3) => {
+                self.selection_action = Some(Action::ForceEscaped);
                 true
             }
             KeyCode::Enter => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new Go Bubble Tea binary `run-from-readme` under `go/pkg/run-from-readme`
- parse shell, bash, sh, and nushell code fences directly from README markdown in Go
- provide a focused split-pane TUI with live filtering, one active selection, and explicit alternate actions
- support `Enter` for the default action, `Ctrl+O` for `run as-is + save`, and `Ctrl+E` for a one-shot escaped run
- persist remembered shell-snippet defaults in `~/.run-from-readme-go/preferences.json`
- wire the new binary into `go/do.nu` and the Go README instructions

## Testing
- `go test ./pkg/run-from-readme`
- `go build ./pkg/run-from-readme`
- non-interactive verification against `/workspace/mac-os/README.md` to confirm:
  - forced `as-is` output and saved preference
  - subsequent default output remains `as-is`
  - one-shot escaped override still works while remembered state remains true
- interactive manual validation in Bubble Tea showing:
  - typed filtering from broader to narrower queries
  - exactly one focused selected item with a separate preview pane
  - saved marker after `Ctrl+O` and reopening the app

## Walkthrough artifacts
[go_run_from_readme_interactive_demo.mp4](https://cursor.com/agents/bc-c62c3cbf-5862-4f65-bbb8-c39c43f4b52f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_run_from_readme_interactive_demo.mp4)
[Go run-from-readme filtered results](https://cursor.com/agents/bc-c62c3cbf-5862-4f65-bbb8-c39c43f4b52f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_run_from_readme_filtered.png)
[Go run-from-readme saved marker](https://cursor.com/agents/bc-c62c3cbf-5862-4f65-bbb8-c39c43f4b52f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_run_from_readme_saved.png)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c62c3cbf-5862-4f65-bbb8-c39c43f4b52f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c62c3cbf-5862-4f65-bbb8-c39c43f4b52f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

