### PR TITLE
Add graph-wizard CLI workflow

### DIFF
--- a/.cursor/skills/graph-wizard/SKILL.md
+++ b/.cursor/skills/graph-wizard/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: graph-wizard
+description: Use when you need to turn a natural-language architecture or topology prompt into maxGraph XML, an mxGraph-compatible XML export, a rendered PNG, a diagram report, and a markdown summary using the `javascript/max-graph-editor` project.
+---
+
+# graph-wizard
+
+## Overview
+
+This skill captures the `graph-wizard` workflow implemented in `javascript/max-graph-editor`.
+
+Use it when the task is to:
+
+- draft a diagram from a plain-English prompt
+- render the diagram to an image
+- inspect the rendered output
+- hand back machine-readable artifacts like XML, JSON, and markdown summary
+
+The workflow is Bun-first and Bash-friendly. Do not depend on Nushell.
+
+
+## When To Use
+
+Use this skill when the user wants something like:
+
+- "make me a graph of ..."
+- "generate a max graph / mxGraph diagram from this description"
+- "render an architecture diagram from a prompt"
+- "iterate on a topology diagram"
+- "produce XML and an image for a system diagram"
+
+Do not use this skill if the task is only about manual editing of an existing diagram in the browser UI with no prompt-driven generation.
+
+
+## Files And Commands
+
+Project root:
+
+- `javascript/max-graph-editor`
+
+Important files:
+
+- `javascript/max-graph-editor/graph-wizard.ts`
+- `javascript/max-graph-editor/src/wizard/`
+- `javascript/max-graph-editor/src/client/main.tsx`
+- `javascript/max-graph-editor/README.md`
+
+Core commands:
+
+1. Install dependencies
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun install
+     ```
+2. Build the browser client
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run build-client
+     ```
+3. Type-check the project
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run check
+     ```
+4. Run the wizard
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun graph-wizard.ts "please give me a graph of a network topology for how AWS Lambda functions work and please show the logging infrastructure"
+     ```
+
+
+## Expected Outputs
+
+The wizard writes an artifact bundle under:
+
+- `javascript/max-graph-editor/out/<timestamp>-<slug>/`
+
+Expect these files:
+
+- `prompt.txt`
+- `diagram-spec.json`
+- `diagram.maxgraph.xml`
+- `diagram.mxgraph.xml`
+- `diagram.png`
+- `diagram-report.json`
+- `diagram-summary.md`
+
+The CLI also prints a JSON result to stdout describing the output directory, provider used, final spec, render report, summary, and artifact paths.
+
+
+## Provider Behavior
+
+- If `OPENAI_API_KEY` is set, `graph-wizard` will attempt to use OpenAI for the first draft.
+- If no API key is configured, or if the OpenAI call fails, the workflow falls back to a deterministic heuristic drafter.
+- The fallback behavior is acceptable and expected in cloud environments where credentials are unavailable.
+
+
+## Validation Workflow
+
+When using this skill, validate in this order:
+
+1. Run:
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run build-client
+     bun run check
+     ```
+2. Run `graph-wizard.ts` with the user's prompt.
+3. Inspect:
+   - stdout JSON
+   - `diagram-report.json`
+   - `diagram-summary.md`
+   - `diagram.png`
+4. If the change affects UI/rendering, manually validate in the browser:
+   - start the server against the generated `diagram.maxgraph.xml`
+   - open normal editor mode
+   - open render-only mode with `?mode=render`
+   - confirm the diagram is legible and the topology is coherent
+
+Recommended manual validation command:
+
+- ```shell
+  export PATH="$HOME/.bun/bin:$PATH"
+  bun src/server.ts "/absolute/path/to/generated/diagram.maxgraph.xml" 3200
+  ```
+
+Then visit:
+
+- `http://127.0.0.1:3200`
+- `http://127.0.0.1:3200/?mode=render`
+
+
+## Output Quality Checklist
+
+Before calling the work done, check:
+
+- nodes referenced by the prompt are present
+- edges form a coherent flow rather than isolated boxes
+- observability/logging nodes are included when the prompt asks for them
+- network/topology prompts do not leave boundary nodes disconnected
+- `diagram.png` is diagram-only and free of editor chrome
+- `diagram-summary.md` explains the result and suggests useful next refinements
+
+
+## Notes For Agents
+
+- Prefer Bun commands directly over `do.nu`.
+- Preserve the generated bundle in `out/`; it is useful evidence.
+- If you improve the workflow itself, update this skill and the project README together.

--- a/javascript/max-graph-editor/.gitignore
+++ b/javascript/max-graph-editor/.gitignore
@@ -1,1 +1,3 @@
 /public/app.js
+/.my/
+/out/

--- a/javascript/max-graph-editor/README.md
+++ b/javascript/max-graph-editor/README.md
@@ -2,7 +2,7 @@
 
 **AI First Draft**: Much of the `max-graph-editor` project was AI-generated. Treat this as a first draft until I prune dead ends and fill in missing pieces.
 
-A minimal [maxGraph][max-graph] editor with live disk sync.
+A minimal [maxGraph][max-graph] editor with live disk sync, plus a `graph-wizard` CLI that drafts and renders diagrams from natural-language prompts.
 
 
 ## Overview
@@ -12,82 +12,66 @@ I like Mermaid diagrams but I need some architecture diagrams which tend to incl
 
 ## Instructions
 
-Follow these instructions to build and run the editor.
+Follow these instructions to build and run the editor or the `graph-wizard` CLI.
 
-1. Activate the Nushell `do` module
-   - ```nushell
-     do activate
-     ```
-2. Generate the `package.json` file (if needed)
-   - ```nushell
-     do package-json
-     ```
-3. Install dependencies
-   - ```nushell
-     do install
-     ```
-4. Build the browser client bundle
-   - ```nushell
-     do build-client
-     ```
-5. Type-check the TypeScript client code
-   - ```nushell
-     do check
-     ```
-6. Start the editor server with the example diagram file
-   - ```nushell
-     do server-start data/example-diagram.xml
-     ```
-7. Confirm server status
-   - ```nushell
-     do server-status
-     ```
-8. Start a Puppeteer-managed browser instance (headful)
-    - ```nushell
-      do browser-start --mode headful --url http://127.0.0.1:3000
-      ```
-9. Confirm browser status
-    - ```nushell
-      do browser-status
-      ```
-10. Capture a screenshot via Puppeteer
-    - ```nushell
-      do screenshot
-      ```
-11. Dynamically inject JavaScript in the page (example: add a box)
-    - ```nushell
-      do browser-eval --js '({label,x,y,width,height}) => { const api = window.__maxGraphEditor; if (!api) return "missing api"; return api.insertVertex(label, x, y, width, height); }' --args-json '{"label":"New Box","x":220,"y":360,"width":140,"height":60}'
-      ```
-12. Optional: inject JavaScript as a screenshot pre-step (single command)
-    - ```nushell
-      do screenshot --pre-js '({label,x,y}) => { const api = window.__maxGraphEditor; if (!api) return null; return api.insertVertex(label, x, y, 140, 60); }' --pre-args-json '{"label":"PreShot Box","x":420,"y":460}'
-      ```
-13. Capture another screenshot after dynamic actions
-    - ```nushell
-      do screenshot
-      ```
-14. Print the newest screenshot path
-    - ```nushell
-      do screenshot-latest
-      ```
-15. Optional: explicit URL/output path
-    - ```nushell
-      do screenshot --url http://127.0.0.1:3000 --out .my/screenshots/manual.png
-      ```
-16. Export a maxGraph XML file to mxGraph-compatible XML
-    - ```nushell
-      do export-mxgraph data/example-diagram.xml
-      ```
-17. Stop both server and browser when done
-    - ```nushell
-      do stop
-      ```
+### Bun / Bash workflow
+
+1. Install dependencies
+   - `bun install`
+2. Build the browser client bundle
+   - `bun run build-client`
+3. Type-check the project
+   - `bun run check`
+4. Start the editor server with the example diagram file
+   - `bun do.ts server-start --diagram data/example-diagram.xml`
+5. Start a Puppeteer-managed browser instance (headful)
+   - `bun do.ts browser-start --mode headful --url http://127.0.0.1:3000`
+6. Capture a screenshot
+   - `bun do.ts screenshot`
+7. Stop the browser and server
+   - `bun do.ts stop`
+
+### `graph-wizard` workflow
+
+Run the wizard with a natural-language prompt.
+
+- `bun graph-wizard.ts "please give me a graph of a network topology for how AWS Lambda functions work and please show the logging infrastructure"`
+
+By default, the wizard:
+
+- drafts a structured diagram spec from the prompt
+- generates maxGraph XML
+- exports mxGraph-compatible XML
+- renders a diagram-only PNG in a headless browser
+- inspects the rendered diagram and applies a small revision pass
+- writes a final summary plus suggested changes
+
+The artifact bundle is written under `out/<timestamp>-<slug>/`:
+
+- `prompt.txt`
+- `diagram-spec.json`
+- `diagram.maxgraph.xml`
+- `diagram.mxgraph.xml`
+- `diagram.png`
+- `diagram-report.json`
+- `diagram-summary.md`
+
+The wizard uses OpenAI automatically when `OPENAI_API_KEY` is set. Otherwise it falls back to a deterministic heuristic drafter so the command still works offline.
+
+### Nushell compatibility
+
+If you still want the old helper module, the `do.nu` wrappers remain available:
+
+- `do install`
+- `do build-client`
+- `do check`
+- `do graph-wizard "describe the graph"`
 
 The key point is that interaction logic is dynamic:
 
-- Use `do browser-eval --js '...'` or `--js-file ...` for browser-side logic.
-- Use `--args-json ...` to parameterize injected JavaScript (no hardcoded operation flags needed).
-- Use `do screenshot --pre-js ...` when you want “mutate page then capture” in one command.
+- Use `bun do.ts browser-eval --js '...'` or `--js-file ...` for browser-side logic.
+- Use `--args-json ...` to parameterize injected JavaScript.
+- Use `bun do.ts screenshot --pre-js ...` when you want “mutate page then capture” in one command.
 
 
 ## Wish List
@@ -98,7 +82,8 @@ General clean-ups, TODOs and things I wish to implement for this project:
 - [x] DONE Ability to add components
 - [x] DONE Ability to delete components
 - [x] DONE Add a minimal maxGraph-to-mxGraph compatibility pass for draw.io workflows (for example, compatibility renames in XML where feasible).
-- [ ] Add a headless diagram-to-image rendering path (for LLM agentic coding loops where image context is useful).
+- [x] DONE Add a headless diagram-to-image rendering path (for LLM agentic coding loops where image context is useful).
+- [ ] Iterate on the `graph-wizard` prompting loop so rendered-image critique can feed richer revisions.
 - [ ] Consider wiring the server to be launched with `my-node-launcher`.
 - [ ] Use Bun instead of npm across my JavaScript projects.
 

--- a/javascript/max-graph-editor/bun.lock
+++ b/javascript/max-graph-editor/bun.lock
@@ -6,13 +6,16 @@
       "name": "max-graph-editor",
       "dependencies": {
         "@maxgraph/core": "0.22.0",
+        "openai": "6.33.0",
         "puppeteer": "24.37.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
       },
       "devDependencies": {
+        "@types/node": "25.5.0",
         "@types/react": "19.2.13",
         "@types/react-dom": "19.2.3",
+        "bun-types": "1.3.11",
         "typescript": "5.9.3",
       },
     },
@@ -28,7 +31,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/react": ["@types/react@19.2.13", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ=="],
 
@@ -63,6 +66,8 @@
     "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -148,6 +153,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openai": ["openai@6.33.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw=="],
+
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
@@ -210,7 +217,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.0", "", {}, "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA=="],
 
@@ -229,5 +236,9 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@types/yauzl/@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
+
+    "@types/yauzl/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/javascript/max-graph-editor/do.nu
+++ b/javascript/max-graph-editor/do.nu
@@ -40,12 +40,12 @@ export def install [] {
 
 export def build-client [] {
     cd $DIR
-    bun build src/client/main.tsx --outfile public/app.js --format esm --target browser
+    run-external bun run build-client
 }
 
 export def check [] {
     cd $DIR
-    bunx tsc --project tsconfig.json --noEmit
+    run-external bun run check
 }
 
 export def run [diagram: string, --port: int = 3000] {
@@ -143,4 +143,9 @@ export def stop [] {
     cd $DIR
     let args = ["stop"]
     run-external bun do.ts ...$args
+}
+
+export def graph-wizard [...args: string] {
+    cd $DIR
+    run-external bun graph-wizard.ts ...$args
 }

--- a/javascript/max-graph-editor/graph-wizard.ts
+++ b/javascript/max-graph-editor/graph-wizard.ts
@@ -1,0 +1,333 @@
+#!/usr/bin/env bun
+import { mkdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { draftHeuristicDiagram } from './src/wizard/heuristic';
+import { applyAutoLayout } from './src/wizard/layout';
+import { draftOpenAiDiagram } from './src/wizard/openai';
+import { renderDiagramArtifacts } from './src/wizard/render';
+import { reviseSpecWithReport } from './src/wizard/revise';
+import type { DiagramDraft, DiagramSpec, WizardArtifacts, WizardResult } from './src/wizard/types';
+import { fileStemFromPrompt, json, titleFromPrompt, writeTextFile } from './src/wizard/utils';
+import { specToMaxGraphXml } from './src/wizard/xml';
+
+const ROOT = dirname(new URL(import.meta.url).pathname);
+
+type Args = {
+  positional: string[];
+  flags: Map<string, string | boolean>;
+};
+
+const args = parseArgs(Bun.argv.slice(2));
+
+try {
+  const result = await run(args);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+async function run(parsed: Args): Promise<WizardResult> {
+  const prompt = getPrompt(parsed);
+  const provider = getFlag(parsed, 'provider', 'auto');
+  const requestedOutDir = getOptionalFlag(parsed, 'out-dir');
+  const renderPort = Number(getFlag(parsed, 'port', '3100'));
+  const maxIterations = Math.max(0, Number(getFlag(parsed, 'max-iterations', '1')));
+
+  if (!Number.isInteger(renderPort) || renderPort <= 0 || renderPort > 65535) {
+    throw new Error(`Invalid --port value: ${renderPort}`);
+  }
+  if (!Number.isInteger(maxIterations) || maxIterations < 0 || maxIterations > 4) {
+    throw new Error(`Invalid --max-iterations value: ${maxIterations}`);
+  }
+
+  const draft = await draftDiagram(prompt, provider);
+  let spec = applyAutoLayout(draft.spec);
+  const outputDir = resolve(ROOT, requestedOutDir || join('out', fileStemFromPrompt(prompt)));
+  await mkdir(outputDir, { recursive: true });
+
+  const promptPath = join(outputDir, 'prompt.txt');
+  const specPath = join(outputDir, 'diagram-spec.json');
+  const xmlPath = join(outputDir, 'diagram.maxgraph.xml');
+  const reportPath = join(outputDir, 'diagram-report.json');
+  const imagePath = join(outputDir, 'diagram.png');
+  const summaryPath = join(outputDir, 'diagram-summary.md');
+  const mxgraphXmlPath = join(outputDir, 'diagram.mxgraph.xml');
+
+  const providerNotes = [...draft.notes];
+  let revisionsApplied = 0;
+  let report = await writeAndRender(spec, {
+    outputDir,
+    prompt,
+    promptPath,
+    specPath,
+    xmlPath,
+    reportPath,
+    imagePath,
+    mxgraphXmlPath,
+    renderPort,
+  });
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    const revision = reviseSpecWithReport(spec, report, prompt);
+    if (!revision.changed) {
+      break;
+    }
+    revisionsApplied += 1;
+    spec = applyAutoLayout(revision.spec);
+    report = await writeAndRender(spec, {
+      outputDir,
+      prompt,
+      promptPath,
+      specPath,
+      xmlPath,
+      reportPath,
+      imagePath,
+      mxgraphXmlPath,
+      renderPort,
+    });
+  }
+
+  const summary = renderSummary(prompt, draft.provider, spec, report, providerNotes, revisionsApplied);
+  await writeTextFile(summaryPath, summary);
+
+  const artifacts: WizardArtifacts = {
+    promptPath,
+    specPath,
+    xmlPath,
+    mxgraphXmlPath,
+    imagePath,
+    reportPath,
+    summaryPath,
+  };
+
+  return {
+    outputDir,
+    provider: draft.provider,
+    spec,
+    report,
+    summary,
+    artifacts,
+    revisionsApplied,
+    providerNotes,
+  };
+}
+
+async function writeAndRender(
+  spec: DiagramSpec,
+  options: {
+    outputDir: string;
+    prompt: string;
+    promptPath: string;
+    specPath: string;
+    xmlPath: string;
+    reportPath: string;
+    imagePath: string;
+    mxgraphXmlPath: string;
+    renderPort: number;
+  },
+) {
+  const xml = specToMaxGraphXml(spec);
+  await writeTextFile(options.promptPath, `${options.prompt}\n`);
+  await writeTextFile(options.specPath, json(spec));
+  await writeTextFile(options.xmlPath, xml);
+  await writeTextFile(options.mxgraphXmlPath, convertMaxGraphXmlToMxGraphXml(xml));
+
+  return renderDiagramArtifacts({
+    rootDir: ROOT,
+    diagramPath: options.xmlPath,
+    imagePath: options.imagePath,
+    reportPath: options.reportPath,
+    port: options.renderPort,
+  });
+}
+
+async function draftDiagram(prompt: string, provider: string): Promise<DiagramDraft> {
+  switch (provider) {
+    case 'heuristic':
+      return draftHeuristicDiagram(prompt);
+    case 'openai':
+      return draftOpenAiDiagram(prompt);
+    case 'auto':
+      return draftOpenAiDiagram(prompt);
+    default:
+      throw new Error(`Unknown --provider value: ${provider}`);
+  }
+}
+
+function renderSummary(
+  prompt: string,
+  provider: string,
+  spec: DiagramSpec,
+  report: WizardResult['report'],
+  providerNotes: string[],
+  revisionsApplied: number,
+) {
+  const lines = [
+    `# ${titleFromPrompt(prompt)}`,
+    '',
+    `Provider: ${provider}`,
+    `Revisions applied after render inspection: ${revisionsApplied}`,
+    '',
+    '## Final diagram description',
+    spec.summary,
+    '',
+    '## Final graph contents',
+    `- Nodes: ${report.vertexCount}`,
+    `- Edges: ${report.edgeCount}`,
+    `- Labels: ${report.labels.join(', ') || '(none)'}`,
+    '',
+    '## Rationale',
+    ...spec.rationale.map((item) => `- ${item}`),
+    '',
+    '## Suggestions for changes',
+    ...spec.changeSuggestions.map((item) => `- ${item}`),
+    '',
+    '## Provider notes',
+    ...providerNotes.map((item) => `- ${item}`),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function getPrompt(parsed: Args) {
+  const fromFlag = getOptionalFlag(parsed, 'prompt');
+  if (fromFlag) {
+    return fromFlag.trim();
+  }
+  if (parsed.positional.length > 0) {
+    return parsed.positional.join(' ').trim();
+  }
+  throw new Error('Missing prompt. Use graph-wizard "describe your graph" or --prompt "..."');
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  const flags = new Map<string, string | boolean>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      positional.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      flags.set(key, true);
+      continue;
+    }
+    flags.set(key, next);
+    i += 1;
+  }
+  return { positional, flags };
+}
+
+function getFlag(parsed: Args, key: string, fallback: string) {
+  const value = parsed.flags.get(key);
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    throw new Error(`Missing value for --${key}`);
+  }
+  return fallback;
+}
+
+function getOptionalFlag(parsed: Args, key: string) {
+  const value = parsed.flags.get(key);
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    throw new Error(`Missing value for --${key}`);
+  }
+  return null;
+}
+
+function convertMaxGraphXmlToMxGraphXml(xml: string) {
+  let output = xml.replace(/\r\n/g, '\n');
+
+  output = output.replace(/<Cell\b[\s\S]*?<\/Cell>/g, (cellBlock) => convertCellBlockToMxGraph(cellBlock));
+  output = output
+    .replace(/<GraphDataModel\b/g, '<mxGraphModel')
+    .replace(/<\/GraphDataModel>/g, '</mxGraphModel>')
+    .replace(/<Cell\b/g, '<mxCell')
+    .replace(/<\/Cell>/g, '</mxCell>')
+    .replace(/<Geometry\b/g, '<mxGeometry')
+    .replace(/<\/Geometry>/g, '</mxGeometry>')
+    .replace(/<Point\b/g, '<mxPoint')
+    .replace(/<\/Point>/g, '</mxPoint>');
+  output = output.replace(/\b_([a-zA-Z][a-zA-Z0-9]*)=/g, '$1=');
+
+  return output;
+}
+
+function convertCellBlockToMxGraph(cellBlock: string) {
+  const openTagMatch = /^<Cell\b[^>]*>/.exec(cellBlock);
+  if (!openTagMatch) {
+    return cellBlock;
+  }
+  const openTag = openTagMatch[0];
+  const closeTag = '</Cell>';
+  if (!cellBlock.endsWith(closeTag)) {
+    return cellBlock;
+  }
+  const body = cellBlock.slice(openTag.length, cellBlock.length - closeTag.length);
+  const extracted = extractStyleNode(body);
+  if (!extracted) {
+    return cellBlock;
+  }
+  const cleanOpenTag = openTag.replace(/\sstyle="[^"]*"/g, '');
+  const withStyleOpenTag = extracted.style.length > 0
+    ? cleanOpenTag.replace(/>$/, ` style="${escapeXmlAttribute(extracted.style)}">`)
+    : cleanOpenTag;
+  return `${withStyleOpenTag}${extracted.bodyWithoutStyle}${closeTag}`;
+}
+
+function extractStyleNode(body: string): { bodyWithoutStyle: string; style: string } | null {
+  const styleNodeRegexes = [
+    /<Object\b([^>]*?)\bas="style"([^>]*)\/>/m,
+    /<Object\b([^>]*?)\bas="style"([^>]*)>([\s\S]*?)<\/Object>/m,
+  ];
+
+  for (const regex of styleNodeRegexes) {
+    const match = regex.exec(body);
+    if (!match || match.index < 0) {
+      continue;
+    }
+    const attributes = parseXmlAttributes(`${match[1] ?? ''} ${match[2] ?? ''}`);
+    const style = buildMxStyle(attributes);
+    const bodyWithoutStyle = `${body.slice(0, match.index)}${body.slice(match.index + match[0].length)}`;
+    return { bodyWithoutStyle, style };
+  }
+  return null;
+}
+
+function parseXmlAttributes(raw: string): Map<string, string> {
+  const attributes = new Map<string, string>();
+  const attrRegex = /([a-zA-Z_:][a-zA-Z0-9_.:-]*)="([^"]*)"/g;
+  for (const match of raw.matchAll(attrRegex)) {
+    attributes.set(match[1], match[2]);
+  }
+  return attributes;
+}
+
+function buildMxStyle(attributes: Map<string, string>) {
+  const styleEntries: string[] = [];
+  for (const [rawKey, value] of attributes.entries()) {
+    if (rawKey === 'as') {
+      continue;
+    }
+    const mxKey = rawKey === 'autoSize' ? 'autosize' : rawKey;
+    styleEntries.push(`${mxKey}=${value}`);
+  }
+  return styleEntries.length === 0 ? '' : `${styleEntries.join(';')};`;
+}
+
+function escapeXmlAttribute(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}

--- a/javascript/max-graph-editor/package.json
+++ b/javascript/max-graph-editor/package.json
@@ -3,15 +3,25 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "build-client": "bun build src/client/main.tsx --outfile public/app.js --format esm --target browser",
+    "check": "tsc --project tsconfig.json --noEmit && tsc --project tsconfig.bun.json --noEmit"
+  },
+  "bin": {
+    "graph-wizard": "./graph-wizard.ts"
+  },
   "dependencies": {
     "@maxgraph/core": "0.22.0",
+    "openai": "6.33.0",
     "puppeteer": "24.37.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@types/node": "25.5.0",
     "@types/react": "19.2.13",
     "@types/react-dom": "19.2.3",
+    "bun-types": "1.3.11",
     "typescript": "5.9.3"
   }
 }

--- a/javascript/max-graph-editor/public/index.html
+++ b/javascript/max-graph-editor/public/index.html
@@ -13,6 +13,11 @@
         color: #f0f3f8;
       }
 
+      body.render-only {
+        background: #ffffff;
+        color: #111827;
+      }
+
       header {
         padding: 12px 16px;
         border-bottom: 1px solid #242a33;
@@ -147,6 +152,25 @@
           width: 100%;
           margin-left: 0;
         }
+      }
+
+      body.render-only main {
+        display: block;
+        padding: 0;
+        height: 100vh;
+        min-height: 100vh;
+      }
+
+      body.render-only .panel {
+        background: #ffffff;
+        border: 0;
+        border-radius: 0;
+      }
+
+      body.render-only #graph {
+        margin: 0;
+        border-radius: 0;
+        min-height: 100vh;
       }
     </style>
   </head>

--- a/javascript/max-graph-editor/src/client/main.tsx
+++ b/javascript/max-graph-editor/src/client/main.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
+  type Cell,
   Graph,
   InternalEvent,
   KeyHandler,
@@ -14,6 +15,41 @@ type SyncMessage = {
   xml?: string;
   source?: string;
   message?: string;
+};
+
+type DiagramNodeReport = {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: string;
+};
+
+type DiagramEdgeReport = {
+  id: string;
+  label: string;
+  sourceId: string;
+  sourceLabel: string;
+  targetId: string;
+  targetLabel: string;
+  style: string;
+};
+
+type DiagramReport = {
+  generatedAt: string;
+  vertexCount: number;
+  edgeCount: number;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  labels: string[];
+  nodes: DiagramNodeReport[];
+  edges: DiagramEdgeReport[];
 };
 
 type MaxGraphEditorApi = {
@@ -38,6 +74,8 @@ type MaxGraphEditorApi = {
   deleteSelection: () => number;
   getXml: () => string;
   setXml: (xml: string) => void;
+  getDiagramReport: () => DiagramReport;
+  prepareForExport: (options?: { padding?: number; maxScale?: number }) => DiagramReport;
 };
 
 const RECT_STYLE = { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#dae8fc', strokeColor: '#6c8ebf' };
@@ -72,6 +110,14 @@ function App() {
     () => `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/sync`,
     [],
   );
+  const renderOnly = useMemo(() => new URLSearchParams(location.search).get('mode') === 'render', []);
+
+  useEffect(() => {
+    document.body.classList.toggle('render-only', renderOnly);
+    return () => {
+      document.body.classList.remove('render-only');
+    };
+  }, [renderOnly]);
 
   useEffect(() => {
     const container = graphContainerRef.current;
@@ -82,25 +128,30 @@ function App() {
     container.tabIndex = 0;
     InternalEvent.disableContextMenu(container);
     const graph = new Graph(container);
-    graph.setConnectable(true);
-    graph.setCellsEditable(true);
-    graph.setPanning(true);
+    graph.setConnectable(!renderOnly);
+    graph.setCellsEditable(!renderOnly);
+    graph.setCellsMovable(!renderOnly);
+    graph.setCellsResizable(!renderOnly);
+    graph.setPanning(!renderOnly);
     new RubberBandHandler(graph);
     graph.getDataModel().addListener(InternalEvent.CHANGE, onGraphModelChanged);
     const onSelectionChanged = () => setSelectionCount(graph.getSelectionCount());
     graph.getSelectionModel().addListener(InternalEvent.CHANGE, onSelectionChanged);
 
-    const keyHandler = new KeyHandler(graph, container);
-    keyHandler.bindKey(46, () => {
-      removeSelection();
-    });
-    keyHandler.bindKey(8, () => {
-      removeSelection();
-    });
-    keyHandlerRef.current = keyHandler;
+    let keyHandler: KeyHandler | null = null;
+    if (!renderOnly) {
+      keyHandler = new KeyHandler(graph, container);
+      keyHandler.bindKey(46, () => {
+        removeSelection();
+      });
+      keyHandler.bindKey(8, () => {
+        removeSelection();
+      });
+      keyHandlerRef.current = keyHandler;
+    }
 
     const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
-    if (popupMenuHandler) {
+    if (popupMenuHandler && !renderOnly) {
       popupMenuHandler.factoryMethod = (menu, cell, mouseEvent) => {
         const point = graph.getPointForEvent(mouseEvent);
         menu.addItem('Add Box', null, () => {
@@ -136,7 +187,9 @@ function App() {
     const focusGraph = () => {
       container.focus();
     };
-    container.addEventListener('pointerdown', focusGraph);
+    if (!renderOnly) {
+      container.addEventListener('pointerdown', focusGraph);
+    }
 
     onSelectionChanged();
     graphRef.current = graph;
@@ -170,6 +223,12 @@ function App() {
           applyingXmlRef.current = false;
         }
       },
+      getDiagramReport() {
+        return buildDiagramReport();
+      },
+      prepareForExport(options) {
+        return prepareForExport(options);
+      },
     };
     window.__maxGraphEditor = api;
 
@@ -177,15 +236,17 @@ function App() {
       if (window.__maxGraphEditor === api) {
         delete window.__maxGraphEditor;
       }
-      container.removeEventListener('pointerdown', focusGraph);
-      keyHandler.onDestroy();
+      if (!renderOnly) {
+        container.removeEventListener('pointerdown', focusGraph);
+      }
+      keyHandler?.onDestroy();
       keyHandlerRef.current = null;
       graph.getSelectionModel().removeListener(onSelectionChanged);
       graph.getDataModel().removeListener(onGraphModelChanged);
       graph.destroy();
       graphRef.current = null;
     };
-  }, []);
+  }, [renderOnly]);
 
   useEffect(() => {
     void loadInitial();
@@ -273,6 +334,12 @@ function App() {
       renderPreview('render error', String(error));
     } finally {
       applyingXmlRef.current = false;
+    }
+
+    if (renderOnly) {
+      window.setTimeout(() => {
+        prepareForExport();
+      }, 25);
     }
   }
 
@@ -425,44 +492,135 @@ function App() {
     setPreview(`[${new Date().toLocaleTimeString()}] ${source}\n\n${nextXml}`);
   }
 
+  function buildDiagramReport(): DiagramReport {
+    const graph = graphRef.current;
+    if (!graph) {
+      return {
+        generatedAt: new Date().toISOString(),
+        vertexCount: 0,
+        edgeCount: 0,
+        bounds: { x: 0, y: 0, width: 0, height: 0 },
+        labels: [],
+        nodes: [],
+        edges: [],
+      };
+    }
+
+    const parent = graph.getDefaultParent() as Cell;
+    const nodes = parent.getChildVertices().map((cell) => {
+      const geometry = cell.getGeometry();
+      return {
+        id: String(cell.id ?? ''),
+        label: graph.getLabel(cell) ?? '',
+        x: geometry?.x ?? 0,
+        y: geometry?.y ?? 0,
+        width: geometry?.width ?? 0,
+        height: geometry?.height ?? 0,
+        style: String(cell.getStyle() ?? ''),
+      };
+    });
+    const edges = parent.getChildEdges().map((cell) => {
+      const source = cell.getTerminal(true);
+      const target = cell.getTerminal(false);
+      return {
+        id: String(cell.id ?? ''),
+        label: graph.getLabel(cell) ?? '',
+        sourceId: String(source?.id ?? ''),
+        sourceLabel: source ? graph.getLabel(source) ?? '' : '',
+        targetId: String(target?.id ?? ''),
+        targetLabel: target ? graph.getLabel(target) ?? '' : '',
+        style: String(cell.getStyle() ?? ''),
+      };
+    });
+
+    const bounds = graph.getGraphBounds();
+    return {
+      generatedAt: new Date().toISOString(),
+      vertexCount: nodes.length,
+      edgeCount: edges.length,
+      bounds: {
+        x: Math.round(bounds.x),
+        y: Math.round(bounds.y),
+        width: Math.round(bounds.width),
+        height: Math.round(bounds.height),
+      },
+      labels: nodes.map((node) => node.label).filter((label) => label.length > 0),
+      nodes,
+      edges,
+    };
+  }
+
+  function prepareForExport(options?: { padding?: number; maxScale?: number }): DiagramReport {
+    const graph = graphRef.current;
+    const container = graphContainerRef.current;
+    if (!graph || !container) {
+      return buildDiagramReport();
+    }
+
+    const padding = Math.max(0, Number(options?.padding ?? 24));
+    const maxScale = Math.max(0.1, Number(options?.maxScale ?? 1.4));
+    graph.refresh();
+    graph.zoomActual();
+
+    const bounds = graph.getGraphBounds();
+    if (bounds.width > 0 && bounds.height > 0) {
+      const availableWidth = Math.max(200, container.clientWidth - padding * 2);
+      const availableHeight = Math.max(200, container.clientHeight - padding * 2);
+      const scale = Math.min(availableWidth / bounds.width, availableHeight / bounds.height, maxScale);
+      if (Number.isFinite(scale) && scale > 0) {
+        graph.zoomTo(scale, false);
+      }
+      graph.center(true, true);
+    }
+
+    graph.refresh();
+    return buildDiagramReport();
+  }
+
   return (
     <>
-      <header>
-        <strong>MaxGraph Editor + Live Disk Sync</strong>
-        <span className={statusClass}>{status}</span>
-      </header>
+      {!renderOnly && (
+        <header>
+          <strong>MaxGraph Editor + Live Disk Sync</strong>
+          <span className={statusClass}>{status}</span>
+        </header>
+      )}
       <main>
+        {!renderOnly && (
+          <section className="panel">
+            <h2>Diagram XML (mxGraphModel)</h2>
+            <textarea value={xml} spellCheck={false} onChange={(event) => onXmlChanged(event.target.value)} />
+          </section>
+        )}
         <section className="panel">
-          <h2>Diagram XML (mxGraphModel)</h2>
-          <textarea value={xml} spellCheck={false} onChange={(event) => onXmlChanged(event.target.value)} />
-        </section>
-        <section className="panel">
-          <h2>Rendered Diagram (MaxGraph)</h2>
-          <div className="graph-toolbar">
-            <input
-              value={nextLabel}
-              onChange={(event) => setNextLabel(event.target.value)}
-              aria-label="New node label"
-              placeholder="Node label"
-            />
-            <button type="button" onClick={() => insertShape('box')}>
-              Add Box
-            </button>
-            <button type="button" onClick={() => insertShape('ellipse')}>
-              Add Ellipse
-            </button>
-            <button type="button" onClick={() => connectSelection()} disabled={selectionCount < 2}>
-              Connect Selected
-            </button>
-            <button type="button" onClick={() => removeSelection()} disabled={selectionCount < 1}>
-              Delete Selected
-            </button>
-            <span className="selection-summary">
-              {selectionCount} selected. Tip: press Delete/Backspace in the graph pane.
-            </span>
-          </div>
+          {!renderOnly && <h2>Rendered Diagram (MaxGraph)</h2>}
+          {!renderOnly && (
+            <div className="graph-toolbar">
+              <input
+                value={nextLabel}
+                onChange={(event) => setNextLabel(event.target.value)}
+                aria-label="New node label"
+                placeholder="Node label"
+              />
+              <button type="button" onClick={() => insertShape('box')}>
+                Add Box
+              </button>
+              <button type="button" onClick={() => insertShape('ellipse')}>
+                Add Ellipse
+              </button>
+              <button type="button" onClick={() => connectSelection()} disabled={selectionCount < 2}>
+                Connect Selected
+              </button>
+              <button type="button" onClick={() => removeSelection()} disabled={selectionCount < 1}>
+                Delete Selected
+              </button>
+              <span className="selection-summary">
+                {selectionCount} selected. Tip: press Delete/Backspace in the graph pane.
+              </span>
+            </div>
+          )}
           <div ref={graphContainerRef} id="graph" />
-          <pre>{preview}</pre>
+          {!renderOnly && <pre>{preview}</pre>}
         </section>
       </main>
     </>

--- a/javascript/max-graph-editor/src/server.ts
+++ b/javascript/max-graph-editor/src/server.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
+type ServerSocket = Bun.ServerWebSocket<unknown>;
+
 const appRoot = new URL('..', import.meta.url).pathname;
 const publicDir = join(appRoot, 'public');
 
@@ -24,7 +26,7 @@ if (!existsSync(diagramPath)) {
   process.exit(1);
 }
 
-const sockets = new Set<ServerWebSocket<unknown>>();
+const sockets = new Set<ServerSocket>();
 
 const server = Bun.serve({
   port,
@@ -103,7 +105,7 @@ function writeDiagram(xml: string) {
   writeFileSync(diagramPath, xml.endsWith('\n') ? xml : `${xml}\n`, 'utf-8');
 }
 
-function broadcast(message: unknown, except?: ServerWebSocket<unknown>) {
+function broadcast(message: unknown, except?: ServerSocket) {
   const json = JSON.stringify(message);
   for (const socket of sockets) {
     if (socket !== except) {

--- a/javascript/max-graph-editor/src/wizard/heuristic.ts
+++ b/javascript/max-graph-editor/src/wizard/heuristic.ts
@@ -118,6 +118,13 @@ function buildHeuristicEdges(nodes: DiagramNode[], lowerPrompt: string): Diagram
   const notifications = findNodeByLabel(nodes, 'Notifications');
   const dataStore = findStorageNode(nodes);
   const observability = findNodeByLabel(nodes, 'Observability');
+  const networkBoundary = findNodeByLabel(nodes, 'Network Boundary');
+
+  if (networkBoundary && gateway) {
+    edges.push(makeEdge('network-ingress', networkBoundary.id, gateway.id, 'ingress', 'flow'));
+  } else if (networkBoundary && lambda) {
+    edges.push(makeEdge('network-entry', networkBoundary.id, lambda.id, 'network path', 'flow'));
+  }
 
   if (user && gateway) {
     edges.push(makeEdge('request', user.id, gateway.id, 'request', 'flow'));

--- a/javascript/max-graph-editor/src/wizard/heuristic.ts
+++ b/javascript/max-graph-editor/src/wizard/heuristic.ts
@@ -1,0 +1,251 @@
+import type { DiagramDraft, DiagramEdge, DiagramNode, DiagramSpec, DiagramStyle } from './types';
+import { titleFromPrompt, unique } from './utils';
+
+const KEYWORD_NODES: Array<{ pattern: RegExp; label: string; kind: DiagramStyle; description: string }> = [
+  { pattern: /\b(user|browser|client|engineer|developer)\b/i, label: 'User', kind: 'user', description: 'Human or client entry point.' },
+  { pattern: /\b(api gateway|gateway|ingress)\b/i, label: 'API Gateway', kind: 'network', description: 'Public entry point and request routing.' },
+  { pattern: /\blambda|function(s)?\b/i, label: 'Lambda Functions', kind: 'lambda', description: 'Compute layer handling event-driven logic.' },
+  { pattern: /\bqueue|sqs|event bus|events\b/i, label: 'Event Bus / Queue', kind: 'queue', description: 'Async messaging and event propagation.' },
+  { pattern: /\bsns|notification\b/i, label: 'Notifications', kind: 'queue', description: 'Fan-out and notification delivery.' },
+  { pattern: /\bdynamodb|database|rds|postgres|mysql\b/i, label: 'Data Store', kind: 'storage', description: 'Primary persistence layer.' },
+  { pattern: /\bs3|bucket|object storage\b/i, label: 'Object Storage', kind: 'storage', description: 'Blob and file storage.' },
+  { pattern: /\bcloudwatch|logging|logs|monitoring|metrics|trace|observability|x-ray\b/i, label: 'Observability', kind: 'observability', description: 'Logs, metrics, and traces.' },
+  { pattern: /\biam|auth|authorization|identity\b/i, label: 'Identity / IAM', kind: 'service', description: 'AuthN/AuthZ and policy enforcement.' },
+  { pattern: /\bnetwork|vpc|subnet|internet\b/i, label: 'Network Boundary', kind: 'network', description: 'Connectivity and network isolation.' },
+];
+
+export function draftHeuristicDiagram(prompt: string): DiagramDraft {
+  const normalized = prompt.trim();
+  const title = titleFromPrompt(normalized);
+  const lower = normalized.toLowerCase();
+  const nodes: DiagramNode[] = [];
+  const notes: string[] = ['Used heuristic drafting because no LLM provider credentials were configured.'];
+
+  for (const candidate of KEYWORD_NODES) {
+    if (candidate.pattern.test(normalized)) {
+      nodes.push({
+        id: toNodeId(candidate.label),
+        label: candidate.label,
+        kind: candidate.kind,
+        description: candidate.description,
+        shape: candidate.kind === 'user' ? 'ellipse' : 'rect',
+      });
+    }
+  }
+
+  if (nodes.length === 0) {
+    nodes.push(
+      {
+        id: 'user',
+        label: 'User',
+        kind: 'user',
+        description: 'Primary actor requesting the system.',
+        shape: 'ellipse',
+      },
+      {
+        id: 'system',
+        label: 'System',
+        kind: 'service',
+        description: 'Core system inferred from the natural-language prompt.',
+      },
+      {
+        id: 'observability',
+        label: 'Observability',
+        kind: 'observability',
+        description: 'Visibility into system behavior.',
+      },
+    );
+    notes.push('No domain-specific keywords matched, so a generic interaction topology was generated.');
+  }
+
+  ensureEssentialNodes(nodes, lower);
+  const edges = buildHeuristicEdges(nodes, lower);
+  const summary = buildSummary(normalized, nodes, edges);
+  const rationale = buildRationale(nodes, lower);
+  const changeSuggestions = buildSuggestions(nodes, edges, lower);
+
+  const spec: DiagramSpec = {
+    title,
+    summary,
+    prompt: normalized,
+    nodes,
+    edges,
+    rationale,
+    changeSuggestions,
+  };
+
+  return { provider: 'heuristic', spec, notes };
+}
+
+function ensureEssentialNodes(nodes: DiagramNode[], lowerPrompt: string) {
+  addIfMissing(nodes, {
+    when: () => !hasNode(nodes, 'user') && !/internal|backend|batch/.test(lowerPrompt),
+    node: { id: 'user', label: 'User', kind: 'user', description: 'Primary actor or calling client.', shape: 'ellipse' },
+  });
+
+  addIfMissing(nodes, {
+    when: () => /lambda/.test(lowerPrompt) && !hasLabel(nodes, 'API Gateway'),
+    node: {
+      id: 'api-gateway',
+      label: 'API Gateway',
+      kind: 'network',
+      description: 'Ingress for Lambda-triggering requests.',
+    },
+  });
+
+  addIfMissing(nodes, {
+    when: () => /lambda/.test(lowerPrompt) && !hasLabel(nodes, 'Observability'),
+    node: {
+      id: 'observability',
+      label: 'Observability',
+      kind: 'observability',
+      description: 'Logs, metrics, and traces for Lambda workloads.',
+    },
+  });
+
+  addIfMissing(nodes, {
+    when: () => nodes.length < 3,
+    node: { id: 'system-core', label: 'Core Service', kind: 'service', description: 'Central processing service.' },
+  });
+}
+
+function buildHeuristicEdges(nodes: DiagramNode[], lowerPrompt: string): DiagramEdge[] {
+  const edges: DiagramEdge[] = [];
+  const user = findNode(nodes, 'user') ?? nodes[0];
+  const gateway = findNodeByLabel(nodes, 'API Gateway');
+  const lambda = findNodeByLabel(nodes, 'Lambda Functions');
+  const queue = findNodeByLabel(nodes, 'Event Bus / Queue');
+  const notifications = findNodeByLabel(nodes, 'Notifications');
+  const dataStore = findStorageNode(nodes);
+  const observability = findNodeByLabel(nodes, 'Observability');
+
+  if (user && gateway) {
+    edges.push(makeEdge('request', user.id, gateway.id, 'request', 'flow'));
+  }
+
+  if (gateway && lambda) {
+    edges.push(makeEdge('invoke', gateway.id, lambda.id, 'invoke', 'control'));
+  }
+
+  if (user && !gateway && lambda) {
+    edges.push(makeEdge('invoke', user.id, lambda.id, 'invoke', 'control'));
+  }
+
+  if (lambda && dataStore) {
+    edges.push(makeEdge('persist', lambda.id, dataStore.id, 'read/write', 'data'));
+  }
+
+  if (lambda && queue) {
+    edges.push(makeEdge('publish', lambda.id, queue.id, 'publish event', 'event'));
+  }
+
+  if (queue && notifications) {
+    edges.push(makeEdge('fanout', queue.id, notifications.id, 'fan-out', 'event'));
+  }
+
+  if (queue && lambda && /event|async|queue|sqs/.test(lowerPrompt)) {
+    edges.push(makeEdge('trigger', queue.id, lambda.id, 'trigger', 'event'));
+  }
+
+  if (lambda && observability) {
+    edges.push(makeEdge('logs', lambda.id, observability.id, 'logs/metrics', 'log'));
+  }
+
+  if (!edges.length) {
+    for (let i = 0; i < nodes.length - 1; i += 1) {
+      edges.push(makeEdge(`flow-${i + 1}`, nodes[i].id, nodes[i + 1].id, '', 'flow'));
+    }
+  }
+
+  return dedupeEdges(edges);
+}
+
+function buildSummary(prompt: string, nodes: DiagramNode[], edges: DiagramEdge[]) {
+  const nodeLabels = nodes.map((node) => node.label);
+  return `Drafted a ${nodes.length}-node, ${edges.length}-edge architecture diagram for "${prompt}" highlighting ${nodeLabels.slice(0, 4).join(', ')}${nodeLabels.length > 4 ? ', and related components' : ''}.`;
+}
+
+function buildRationale(nodes: DiagramNode[], lowerPrompt: string) {
+  const rationale = [
+    `Started from the entities explicitly mentioned or strongly implied by the prompt.`,
+    `Grouped the draft around execution flow first, then persistence and observability.`,
+  ];
+
+  if (/logging|observability|metrics|trace/.test(lowerPrompt)) {
+    rationale.push('Promoted observability to a first-class node because the prompt explicitly asked for it.');
+  }
+
+  if (nodes.some((node) => node.kind === 'lambda')) {
+    rationale.push('Represented Lambda separately so request paths and async event paths stay readable.');
+  }
+
+  return rationale;
+}
+
+function buildSuggestions(nodes: DiagramNode[], edges: DiagramEdge[], lowerPrompt: string) {
+  const suggestions = [
+    'Review whether any missing infrastructure boundaries should be grouped visually, such as VPC or account boundaries.',
+    'Consider adding failure paths, retries, or DLQs if operational behavior matters.',
+  ];
+
+  if (!nodes.some((node) => node.kind === 'storage')) {
+    suggestions.push('If the system persists state, add the specific data stores rather than leaving them implied.');
+  }
+  if (!/security|iam|auth/.test(lowerPrompt)) {
+    suggestions.push('If security architecture matters, add IAM, auth, or trust boundaries as explicit nodes.');
+  }
+  if (edges.every((edge) => edge.label)) {
+    suggestions.push('Edge labels are present; tighten them further if protocol-level detail matters.');
+  }
+
+  return unique(suggestions);
+}
+
+function addIfMissing(nodes: DiagramNode[], options: { when: () => boolean; node: DiagramNode }) {
+  if (options.when() && !hasNode(nodes, options.node.id) && !hasLabel(nodes, options.node.label)) {
+    nodes.push(options.node);
+  }
+}
+
+function findStorageNode(nodes: DiagramNode[]) {
+  return nodes.find((node) => node.kind === 'storage') ?? null;
+}
+
+function findNode(nodes: DiagramNode[], id: string) {
+  return nodes.find((node) => node.id === id) ?? null;
+}
+
+function findNodeByLabel(nodes: DiagramNode[], label: string) {
+  return nodes.find((node) => node.label === label) ?? null;
+}
+
+function hasNode(nodes: DiagramNode[], id: string) {
+  return nodes.some((node) => node.id === id);
+}
+
+function hasLabel(nodes: DiagramNode[], label: string) {
+  return nodes.some((node) => node.label === label);
+}
+
+function makeEdge(id: string, source: string, target: string, label: string, kind: DiagramEdge['kind']): DiagramEdge {
+  return { id, source, target, label, kind };
+}
+
+function dedupeEdges(edges: DiagramEdge[]) {
+  const seen = new Set<string>();
+  return edges.filter((edge) => {
+    const key = `${edge.source}->${edge.target}:${edge.label ?? ''}:${edge.kind ?? ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function toNodeId(label: string) {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/javascript/max-graph-editor/src/wizard/layout.ts
+++ b/javascript/max-graph-editor/src/wizard/layout.ts
@@ -1,0 +1,85 @@
+import type { DiagramNode, DiagramSpec } from './types';
+
+const DEFAULT_WIDTH = 180;
+const DEFAULT_HEIGHT = 72;
+const HORIZONTAL_GAP = 220;
+const VERTICAL_GAP = 150;
+const START_X = 80;
+const START_Y = 80;
+
+export function applyAutoLayout(spec: DiagramSpec): DiagramSpec {
+  const incomingCount = new Map<string, number>();
+  const outgoingCount = new Map<string, number>();
+
+  for (const edge of spec.edges) {
+    incomingCount.set(edge.target, (incomingCount.get(edge.target) ?? 0) + 1);
+    outgoingCount.set(edge.source, (outgoingCount.get(edge.source) ?? 0) + 1);
+  }
+
+  const orderedNodes = [...spec.nodes].sort((a, b) => scoreNode(a, incomingCount, outgoingCount) - scoreNode(b, incomingCount, outgoingCount));
+
+  const layerByNodeId = new Map<string, number>();
+  const nodeIds = new Set(spec.nodes.map((node) => node.id));
+
+  for (const node of orderedNodes) {
+    const parentLayers = spec.edges
+      .filter((edge) => edge.target === node.id && nodeIds.has(edge.source))
+      .map((edge) => layerByNodeId.get(edge.source) ?? 0);
+    const layer = parentLayers.length === 0 ? 0 : Math.max(...parentLayers) + 1;
+    layerByNodeId.set(node.id, layer);
+  }
+
+  const lanes = new Map<number, DiagramNode[]>();
+  for (const node of orderedNodes) {
+    const layer = layerByNodeId.get(node.id) ?? 0;
+    const lane = lanes.get(layer) ?? [];
+    lane.push(node);
+    lanes.set(layer, lane);
+  }
+
+  const nodes = spec.nodes.map((node) => {
+    const layer = layerByNodeId.get(node.id) ?? 0;
+    const lane = lanes.get(layer) ?? [];
+    const index = lane.findIndex((candidate) => candidate.id === node.id);
+    return {
+      ...node,
+      x: node.x ?? START_X + layer * HORIZONTAL_GAP,
+      y: node.y ?? START_Y + index * VERTICAL_GAP,
+      width: node.width ?? defaultWidth(node),
+      height: node.height ?? defaultHeight(node),
+    };
+  });
+
+  return {
+    ...spec,
+    nodes,
+  };
+}
+
+function scoreNode(
+  node: DiagramNode,
+  incomingCount: Map<string, number>,
+  outgoingCount: Map<string, number>,
+) {
+  const incoming = incomingCount.get(node.id) ?? 0;
+  const outgoing = outgoingCount.get(node.id) ?? 0;
+  const roleBias = node.kind === 'user' ? -2 : node.kind === 'network' ? -1 : node.kind === 'observability' ? 2 : 0;
+  return incoming * 10 - outgoing * 5 + roleBias;
+}
+
+function defaultWidth(node: DiagramNode) {
+  if (node.label.length > 18) {
+    return 220;
+  }
+  if (node.kind === 'observability' || node.kind === 'network') {
+    return 190;
+  }
+  return DEFAULT_WIDTH;
+}
+
+function defaultHeight(node: DiagramNode) {
+  if (node.description && node.description.length > 70) {
+    return 86;
+  }
+  return DEFAULT_HEIGHT;
+}

--- a/javascript/max-graph-editor/src/wizard/openai.ts
+++ b/javascript/max-graph-editor/src/wizard/openai.ts
@@ -1,0 +1,153 @@
+import OpenAI from 'openai';
+import { draftHeuristicDiagram } from './heuristic';
+import type { DiagramDraft, DiagramEdge, DiagramNode, DiagramSpec } from './types';
+
+const DEFAULT_MODEL = 'gpt-4.1-mini';
+
+export async function draftOpenAiDiagram(prompt: string): Promise<DiagramDraft> {
+  const apiKey = Bun.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return draftHeuristicDiagram(prompt);
+  }
+
+  const client = new OpenAI({ apiKey });
+  const model = Bun.env.OPENAI_MODEL || DEFAULT_MODEL;
+
+  try {
+    const response = await client.responses.create({
+      model,
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'input_text',
+              text:
+                'You design clear architecture diagrams for maxGraph. Return JSON only. Produce a pragmatic first draft for an engineering diagram. Use 4-10 nodes, concise labels, and include observability when the prompt implies logs, metrics, or traces. Prefer graph readability over completeness.',
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: [
+                'Create a maxGraph-ready diagram specification for this prompt:',
+                prompt,
+                '',
+                'Return JSON with this exact shape:',
+                '{',
+                '  "title": string,',
+                '  "summary": string,',
+                '  "prompt": string,',
+                '  "nodes": [{ "id": string, "label": string, "kind": "service"|"storage"|"queue"|"network"|"user"|"observability"|"lambda"|"group", "description"?: string, "shape"?: "rect"|"ellipse" }],',
+                '  "edges": [{ "id": string, "source": string, "target": string, "label"?: string, "kind"?: "flow"|"data"|"event"|"control"|"log" }],',
+                '  "rationale": string[],',
+                '  "changeSuggestions": string[]',
+                '}',
+                '',
+                'Requirements:',
+                '- Use stable lowercase kebab-case ids.',
+                '- Reference only node ids that exist.',
+                '- Keep edge labels short.',
+                '- Do not include markdown fences.',
+              ].join('\n'),
+            },
+          ],
+        },
+      ],
+    });
+
+    const raw = response.output_text.trim();
+    const parsed = JSON.parse(raw) as DiagramSpec;
+    const spec = normalizeSpec(parsed, prompt);
+
+    return {
+      provider: 'openai',
+      spec,
+      notes: [`Drafted with OpenAI model ${model}.`],
+    };
+  } catch (error) {
+    const fallback = draftHeuristicDiagram(prompt);
+    fallback.notes.unshift(`OpenAI drafting failed, so the heuristic provider was used instead: ${String(error)}`);
+    return fallback;
+  }
+}
+
+function normalizeSpec(input: DiagramSpec, prompt: string): DiagramSpec {
+  const nodes = normalizeNodes(Array.isArray(input.nodes) ? input.nodes : []);
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges = normalizeEdges(Array.isArray(input.edges) ? input.edges : []).filter(
+    (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target),
+  );
+
+  return {
+    title: String(input.title || prompt).trim(),
+    summary: String(input.summary || '').trim() || `Drafted diagram for "${prompt}".`,
+    prompt,
+    nodes,
+    edges,
+    rationale: Array.isArray(input.rationale) ? input.rationale.map(String).map((value) => value.trim()).filter(Boolean) : [],
+    changeSuggestions: Array.isArray(input.changeSuggestions)
+      ? input.changeSuggestions.map(String).map((value) => value.trim()).filter(Boolean)
+      : [],
+  };
+}
+
+function normalizeNodes(nodes: DiagramNode[]): DiagramNode[] {
+  const seen = new Set<string>();
+  const output: DiagramNode[] = [];
+  for (const node of nodes) {
+    const id = toId(node.id || node.label || `node-${output.length + 1}`);
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    output.push({
+      id,
+      label: String(node.label || id).trim(),
+      kind: normalizeKind(node.kind),
+      description: typeof node.description === 'string' ? node.description.trim() : undefined,
+      shape: node.shape === 'ellipse' ? 'ellipse' : 'rect',
+    });
+  }
+  return output;
+}
+
+function normalizeEdges(edges: DiagramEdge[]): DiagramEdge[] {
+  const output: DiagramEdge[] = [];
+  for (const edge of edges) {
+    const source = toId(edge.source);
+    const target = toId(edge.target);
+    if (!source || !target) {
+      continue;
+    }
+    output.push({
+      id: toId(edge.id || `${source}-to-${target}`),
+      source,
+      target,
+      label: typeof edge.label === 'string' ? edge.label.trim() : '',
+      kind: normalizeEdgeKind(edge.kind),
+    });
+  }
+  return output;
+}
+
+function normalizeKind(kind: DiagramNode['kind']): DiagramNode['kind'] {
+  const allowed = new Set(['service', 'storage', 'queue', 'network', 'user', 'observability', 'lambda', 'group']);
+  return allowed.has(String(kind)) ? (kind as DiagramNode['kind']) : 'service';
+}
+
+function normalizeEdgeKind(kind: DiagramEdge['kind']): DiagramEdge['kind'] {
+  const allowed = new Set(['flow', 'data', 'event', 'control', 'log']);
+  return allowed.has(String(kind)) ? (kind as DiagramEdge['kind']) : 'flow';
+}
+
+function toId(value: string) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/javascript/max-graph-editor/src/wizard/render.ts
+++ b/javascript/max-graph-editor/src/wizard/render.ts
@@ -1,0 +1,181 @@
+import { existsSync } from 'node:fs';
+import { mkdir, open, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import puppeteer from 'puppeteer';
+import type { DiagramReport } from './types';
+
+export type RenderOptions = {
+  rootDir: string;
+  diagramPath: string;
+  imagePath: string;
+  reportPath: string;
+  port?: number;
+  width?: number;
+  height?: number;
+};
+
+type ServerState = {
+  pid: number;
+  port: number;
+  diagramPath: string;
+  logPath: string;
+  startedAt: string;
+};
+
+const RUN_DIR_NAME = '.my/run';
+const SERVER_STATE_NAME = 'server.json';
+const SERVER_LOG_NAME = 'server.log';
+
+type BrowserPageApi = {
+  prepareForExport: (options?: { padding?: number; maxScale?: number }) => DiagramReport;
+};
+
+export async function renderDiagramArtifacts(options: RenderOptions): Promise<DiagramReport> {
+  const rootDir = resolve(options.rootDir);
+  const diagramPath = resolve(options.diagramPath);
+  const imagePath = resolve(options.imagePath);
+  const reportPath = resolve(options.reportPath);
+  const port = options.port ?? 3100;
+  const width = options.width ?? 1600;
+  const height = options.height ?? 1000;
+  const runDir = join(rootDir, RUN_DIR_NAME);
+  const serverStatePath = join(runDir, SERVER_STATE_NAME);
+  const serverLogPath = join(runDir, SERVER_LOG_NAME);
+
+  await mkdir(runDir, { recursive: true });
+  await mkdir(dirname(imagePath), { recursive: true });
+  await mkdir(dirname(reportPath), { recursive: true });
+
+  const previousState = await readJson<ServerState>(serverStatePath);
+  let startedServerPid: number | null = null;
+
+  if (!(await isHttpReachable(`http://127.0.0.1:${port}/api/diagram`))) {
+    if (previousState?.pid && isPidAlive(previousState.pid)) {
+      throw new Error(
+        `Port ${port} is expected to be available for graph-wizard rendering, but an existing managed server is active for a different diagram.`,
+      );
+    }
+
+    const logFile = await open(serverLogPath, 'a');
+    const proc = Bun.spawn({
+      cmd: ['bun', 'src/server.ts', diagramPath, String(port)],
+      cwd: rootDir,
+      stdout: logFile.fd,
+      stderr: logFile.fd,
+      stdin: 'ignore',
+      detached: true,
+    });
+    proc.unref();
+    startedServerPid = proc.pid;
+    await logFile.close();
+
+    const state: ServerState = {
+      pid: proc.pid,
+      port,
+      diagramPath,
+      logPath: serverLogPath,
+      startedAt: new Date().toISOString(),
+    };
+    await writeFile(serverStatePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+
+    const ready = await waitForHttp(`http://127.0.0.1:${port}/api/diagram`, 10_000);
+    if (!ready) {
+      throw new Error(`Rendering server did not become ready on port ${port}. Check ${serverLogPath}`);
+    }
+  }
+
+  const browser = await puppeteer.launch({
+    headless: true,
+    defaultViewport: { width, height, deviceScaleFactor: 1 },
+    args: ['--no-first-run', '--no-default-browser-check'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}/?mode=render`, { waitUntil: 'networkidle0' });
+    await page.waitForFunction(() => {
+      const browserWindow = window as typeof window & { __maxGraphEditor?: BrowserPageApi };
+      return Boolean(browserWindow.__maxGraphEditor);
+    }, { timeout: 15_000 });
+    const report = await page.evaluate(async () => {
+      const browserWindow = window as typeof window & { __maxGraphEditor?: BrowserPageApi };
+      const api = browserWindow.__maxGraphEditor;
+      if (!api) {
+        throw new Error('Missing editor API');
+      }
+      await new Promise((resolveWait) => window.setTimeout(resolveWait, 250));
+      return api.prepareForExport({ padding: 48, maxScale: 1.25 });
+    });
+    const graphHandle = await page.$('#graph');
+    if (!graphHandle) {
+      throw new Error('Could not locate #graph in render mode');
+    }
+    await graphHandle.screenshot({ path: imagePath, type: 'png' });
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    return report as DiagramReport;
+  } finally {
+    await browser.close();
+    if (startedServerPid) {
+      await stopProcess(startedServerPid);
+      await rm(serverStatePath, { force: true });
+    }
+  }
+}
+
+async function waitForHttp(url: string, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isHttpReachable(url)) {
+      return true;
+    }
+    await Bun.sleep(250);
+  }
+  return false;
+}
+
+async function isHttpReachable(url: string) {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 1_000);
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    return response.ok || response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson<T>(path: string): Promise<T | null> {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isPidAlive(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function stopProcess(pid: number) {
+  if (!isPidAlive(pid)) {
+    return;
+  }
+  process.kill(pid, 'SIGTERM');
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return;
+    }
+    await Bun.sleep(100);
+  }
+  process.kill(pid, 'SIGKILL');
+}

--- a/javascript/max-graph-editor/src/wizard/revise.ts
+++ b/javascript/max-graph-editor/src/wizard/revise.ts
@@ -1,0 +1,109 @@
+import type { DiagramReport, DiagramSpec } from './types';
+
+export function reviseSpecWithReport(spec: DiagramSpec, report: DiagramReport, prompt: string) {
+  const next: DiagramSpec = {
+    ...spec,
+    nodes: [...spec.nodes],
+    edges: [...spec.edges],
+    rationale: [...spec.rationale],
+    changeSuggestions: [...spec.changeSuggestions],
+  };
+
+  const lowerPrompt = prompt.toLowerCase();
+  let changed = false;
+
+  if (/\b(logging|logs|observability|metrics|trace|cloudwatch)\b/.test(lowerPrompt)) {
+    const hasObservability = next.nodes.some((node) => node.kind === 'observability');
+    if (!hasObservability) {
+      next.nodes.push({
+        id: 'observability',
+        label: 'Observability',
+        kind: 'observability',
+        description: 'Logs, metrics, and traces collected for the system.',
+      });
+      const lambdaNode = next.nodes.find((node) => node.kind === 'lambda');
+      const primaryNode = lambdaNode ?? next.nodes.find((node) => node.kind !== 'user') ?? next.nodes[0];
+      if (primaryNode) {
+        next.edges.push({
+          id: `${primaryNode.id}-to-observability`,
+          source: primaryNode.id,
+          target: 'observability',
+          label: 'logs/metrics',
+          kind: 'log',
+        });
+      }
+      next.rationale.push('Added an observability sink after inspecting the draft against the prompt requirements.');
+      changed = true;
+    }
+  }
+
+  if (/\blambda\b/.test(lowerPrompt)) {
+    const hasGateway = next.nodes.some((node) => node.label === 'API Gateway');
+    const lambdaNode = next.nodes.find((node) => node.kind === 'lambda');
+    const userNode = next.nodes.find((node) => node.kind === 'user');
+    if (lambdaNode && userNode && !hasGateway) {
+      next.nodes.unshift({
+        id: 'api-gateway',
+        label: 'API Gateway',
+        kind: 'network',
+        description: 'Ingress and routing for Lambda requests.',
+      });
+      next.edges = next.edges.filter((edge) => !(edge.source === userNode.id && edge.target === lambdaNode.id));
+      next.edges.unshift(
+        {
+          id: `${userNode.id}-to-api-gateway`,
+          source: userNode.id,
+          target: 'api-gateway',
+          label: 'request',
+          kind: 'flow',
+        },
+        {
+          id: `api-gateway-to-${lambdaNode.id}`,
+          source: 'api-gateway',
+          target: lambdaNode.id,
+          label: 'invoke',
+          kind: 'control',
+        },
+      );
+      next.rationale.push('Inserted an API Gateway in the request path after inspection to improve AWS Lambda topology clarity.');
+      changed = true;
+    }
+  }
+
+  if (report.vertexCount < 3 && next.nodes.length < 3) {
+    next.changeSuggestions.push('The diagram is still minimal. Consider adding operational or infrastructure context.');
+  }
+
+  return { changed, spec: dedupeSpec(next) };
+}
+
+function dedupeSpec(spec: DiagramSpec): DiagramSpec {
+  const nodeIds = new Set<string>();
+  const nodes = spec.nodes.filter((node) => {
+    if (nodeIds.has(node.id)) {
+      return false;
+    }
+    nodeIds.add(node.id);
+    return true;
+  });
+
+  const edgeIds = new Set<string>();
+  const edges = spec.edges.filter((edge) => {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) {
+      return false;
+    }
+    if (edgeIds.has(edge.id)) {
+      return false;
+    }
+    edgeIds.add(edge.id);
+    return true;
+  });
+
+  return {
+    ...spec,
+    nodes,
+    edges,
+    rationale: [...new Set(spec.rationale)],
+    changeSuggestions: [...new Set(spec.changeSuggestions)],
+  };
+}

--- a/javascript/max-graph-editor/src/wizard/revise.ts
+++ b/javascript/max-graph-editor/src/wizard/revise.ts
@@ -70,6 +70,37 @@ export function reviseSpecWithReport(spec: DiagramSpec, report: DiagramReport, p
     }
   }
 
+  const networkNode = next.nodes.find((node) => node.kind === 'network');
+  if (networkNode) {
+    const isConnected = next.edges.some((edge) => edge.source === networkNode.id || edge.target === networkNode.id);
+    const gatewayNode = next.nodes.find((node) => node.label === 'API Gateway');
+    const userNode = next.nodes.find((node) => node.kind === 'user');
+    if (!isConnected) {
+      if (gatewayNode) {
+        next.edges.unshift({
+          id: `${networkNode.id}-to-${gatewayNode.id}`,
+          source: networkNode.id,
+          target: gatewayNode.id,
+          label: 'ingress',
+          kind: 'flow',
+        });
+        changed = true;
+      } else if (userNode) {
+        next.edges.unshift({
+          id: `${userNode.id}-to-${networkNode.id}`,
+          source: userNode.id,
+          target: networkNode.id,
+          label: 'network path',
+          kind: 'flow',
+        });
+        changed = true;
+      }
+      if (changed) {
+        next.rationale.push('Connected an otherwise isolated network node after render inspection so the topology reads as a single flow.');
+      }
+    }
+  }
+
   if (report.vertexCount < 3 && next.nodes.length < 3) {
     next.changeSuggestions.push('The diagram is still minimal. Consider adding operational or infrastructure context.');
   }

--- a/javascript/max-graph-editor/src/wizard/types.ts
+++ b/javascript/max-graph-editor/src/wizard/types.ts
@@ -1,0 +1,95 @@
+export type DiagramStyle = 'service' | 'storage' | 'queue' | 'network' | 'user' | 'observability' | 'lambda' | 'group';
+
+export type DiagramNode = {
+  id: string;
+  label: string;
+  kind: DiagramStyle;
+  description?: string;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  shape?: 'rect' | 'ellipse';
+};
+
+export type DiagramEdge = {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  kind?: 'flow' | 'data' | 'event' | 'control' | 'log';
+};
+
+export type DiagramSpec = {
+  title: string;
+  summary: string;
+  prompt: string;
+  nodes: DiagramNode[];
+  edges: DiagramEdge[];
+  rationale: string[];
+  changeSuggestions: string[];
+};
+
+export type WizardProvider = 'heuristic' | 'openai';
+
+export type DiagramDraft = {
+  provider: WizardProvider;
+  spec: DiagramSpec;
+  notes: string[];
+};
+
+export type DiagramNodeReport = {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: string;
+};
+
+export type DiagramEdgeReport = {
+  id: string;
+  label: string;
+  sourceId: string;
+  sourceLabel: string;
+  targetId: string;
+  targetLabel: string;
+  style: string;
+};
+
+export type DiagramReport = {
+  generatedAt: string;
+  vertexCount: number;
+  edgeCount: number;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  labels: string[];
+  nodes: DiagramNodeReport[];
+  edges: DiagramEdgeReport[];
+};
+
+export type WizardArtifacts = {
+  promptPath: string;
+  specPath: string;
+  xmlPath: string;
+  mxgraphXmlPath: string;
+  imagePath: string;
+  reportPath: string;
+  summaryPath: string;
+};
+
+export type WizardResult = {
+  outputDir: string;
+  provider: WizardProvider;
+  spec: DiagramSpec;
+  report: DiagramReport;
+  summary: string;
+  artifacts: WizardArtifacts;
+  revisionsApplied: number;
+  providerNotes: string[];
+};

--- a/javascript/max-graph-editor/src/wizard/utils.ts
+++ b/javascript/max-graph-editor/src/wizard/utils.ts
@@ -1,0 +1,62 @@
+import { dirname } from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+
+export function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'diagram';
+}
+
+export function stamp() {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mi = String(now.getMinutes()).padStart(2, '0');
+  const ss = String(now.getSeconds()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}-${hh}${mi}${ss}`;
+}
+
+export function ensureArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+export function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+export function escapeXmlText(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+export function json(value: unknown) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export async function writeTextFile(path: string, contents: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents.endsWith('\n') ? contents : `${contents}\n`, 'utf8');
+}
+
+export function titleFromPrompt(prompt: string) {
+  const cleaned = prompt.trim().replace(/\s+/g, ' ');
+  if (cleaned.length <= 72) {
+    return cleaned;
+  }
+  return `${cleaned.slice(0, 69).trimEnd()}...`;
+}
+
+export function fileStemFromPrompt(prompt: string) {
+  return `${stamp()}-${slugify(basename(titleFromPrompt(prompt)))}`;
+}

--- a/javascript/max-graph-editor/src/wizard/xml.ts
+++ b/javascript/max-graph-editor/src/wizard/xml.ts
@@ -1,0 +1,75 @@
+import type { DiagramEdge, DiagramNode, DiagramSpec } from './types';
+import { escapeXmlText } from './utils';
+
+const STYLE_BY_KIND: Record<string, Record<string, string | number>> = {
+  service: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#dae8fc', strokeColor: '#6c8ebf' },
+  storage: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#d5e8d4', strokeColor: '#82b366' },
+  queue: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#ffe6cc', strokeColor: '#d79b00' },
+  network: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#e1d5e7', strokeColor: '#9673a6' },
+  user: { shape: 'ellipse', whiteSpace: 'wrap', html: 1, fillColor: '#f8cecc', strokeColor: '#b85450' },
+  observability: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#fff2cc', strokeColor: '#d6b656' },
+  lambda: { rounded: 1, whiteSpace: 'wrap', html: 1, fillColor: '#f5f5f5', strokeColor: '#666666' },
+  group: { rounded: 1, dashed: 1, whiteSpace: 'wrap', html: 1, fillColor: '#f5f5f5', strokeColor: '#999999' },
+};
+
+const EDGE_STYLE_BY_KIND: Record<string, Record<string, string | number>> = {
+  flow: { endArrow: 'block', html: 1, rounded: 1, strokeColor: '#6c8ebf' },
+  data: { endArrow: 'block', html: 1, rounded: 1, strokeColor: '#82b366' },
+  event: { endArrow: 'block', html: 1, rounded: 1, dashed: 1, strokeColor: '#d79b00' },
+  control: { endArrow: 'block', html: 1, rounded: 1, strokeColor: '#9673a6' },
+  log: { endArrow: 'block', html: 1, rounded: 1, dashed: 1, strokeColor: '#d6b656' },
+};
+
+export function specToMaxGraphXml(spec: DiagramSpec) {
+  const nodeIndex = new Map(spec.nodes.map((node, index) => [node.id, index]));
+  const edgeOffset = spec.nodes.length + 2;
+  const cells = [
+    '  <root>',
+    '    <Cell id="0">',
+    '      <Object as="style" />',
+    '    </Cell>',
+    '    <Cell id="1" parent="0">',
+    '      <Object as="style" />',
+    '    </Cell>',
+    ...spec.nodes.map((node, index) => renderNode(node, index + 2)),
+    ...spec.edges.map((edge, index) => renderEdge(edge, edgeOffset + index, nodeIndex)),
+    '  </root>',
+  ];
+
+  return ['<GraphDataModel>', ...cells, '</GraphDataModel>'].join('\n');
+}
+
+function renderNode(node: DiagramNode, cellId: number) {
+  const style = node.shape === 'ellipse'
+    ? { ...STYLE_BY_KIND[node.kind], shape: 'ellipse' }
+    : STYLE_BY_KIND[node.kind] ?? STYLE_BY_KIND.service;
+  const geometry = `      <Geometry _x="${round(node.x ?? 0)}" _y="${round(node.y ?? 0)}" _width="${round(node.width ?? 180)}" _height="${round(node.height ?? 72)}" as="geometry" />`;
+  return [
+    `    <Cell id="${cellId}" value="${escapeXmlText(node.label)}" vertex="1" parent="1">`,
+    geometry,
+    `      <Object ${renderStyleAttributes(style)} as="style" />`,
+    '    </Cell>',
+  ].join('\n');
+}
+
+function renderEdge(edge: DiagramEdge, cellId: number, nodeIndex: Map<string, number>) {
+  const sourceCellId = (nodeIndex.get(edge.source) ?? 0) + 2;
+  const targetCellId = (nodeIndex.get(edge.target) ?? 0) + 2;
+  const style = EDGE_STYLE_BY_KIND[edge.kind ?? 'flow'] ?? EDGE_STYLE_BY_KIND.flow;
+  return [
+    `    <Cell id="${cellId}" value="${escapeXmlText(edge.label ?? '')}" edge="1" parent="1" source="${sourceCellId}" target="${targetCellId}">`,
+    '      <Geometry relative="1" as="geometry" />',
+    `      <Object ${renderStyleAttributes(style)} as="style" />`,
+    '    </Cell>',
+  ].join('\n');
+}
+
+function renderStyleAttributes(style: Record<string, string | number>) {
+  return Object.entries(style)
+    .map(([key, value]) => `${key}="${escapeXmlText(String(value))}"`)
+    .join(' ');
+}
+
+function round(value: number) {
+  return Math.round(value);
+}

--- a/javascript/max-graph-editor/tsconfig.bun.json
+++ b/javascript/max-graph-editor/tsconfig.bun.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "types": ["bun-types", "node"],
+    "lib": ["ES2022", "DOM"],
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["do.ts", "graph-wizard.ts", "src/server.ts", "src/wizard/**/*"]
+}

--- a/llm-agent/skills/graph-wizard/SKILL.md
+++ b/llm-agent/skills/graph-wizard/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: graph-wizard
+description: Use when you need to turn a natural-language architecture or topology prompt into maxGraph XML, an mxGraph-compatible XML export, a rendered PNG, a diagram report, and a markdown summary using the `javascript/max-graph-editor` project.
+---
+
+# graph-wizard
+
+## Overview
+
+This skill captures the `graph-wizard` workflow implemented in `javascript/max-graph-editor`.
+
+Use it when the task is to:
+
+- draft a diagram from a plain-English prompt
+- render the diagram to an image
+- inspect the rendered output
+- hand back machine-readable artifacts like XML, JSON, and markdown summary
+
+The workflow is Bun-first and Bash-friendly. Do not depend on Nushell.
+
+
+## When To Use
+
+Use this skill when the user wants something like:
+
+- "make me a graph of ..."
+- "generate a max graph / mxGraph diagram from this description"
+- "render an architecture diagram from a prompt"
+- "iterate on a topology diagram"
+- "produce XML and an image for a system diagram"
+
+Do not use this skill if the task is only about manual editing of an existing diagram in the browser UI with no prompt-driven generation.
+
+
+## Files And Commands
+
+Project root:
+
+- `javascript/max-graph-editor`
+
+Important files:
+
+- `javascript/max-graph-editor/graph-wizard.ts`
+- `javascript/max-graph-editor/src/wizard/`
+- `javascript/max-graph-editor/src/client/main.tsx`
+- `javascript/max-graph-editor/README.md`
+
+Core commands:
+
+1. Install dependencies
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun install
+     ```
+2. Build the browser client
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run build-client
+     ```
+3. Type-check the project
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run check
+     ```
+4. Run the wizard
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun graph-wizard.ts "please give me a graph of a network topology for how AWS Lambda functions work and please show the logging infrastructure"
+     ```
+
+
+## Expected Outputs
+
+The wizard writes an artifact bundle under:
+
+- `javascript/max-graph-editor/out/<timestamp>-<slug>/`
+
+Expect these files:
+
+- `prompt.txt`
+- `diagram-spec.json`
+- `diagram.maxgraph.xml`
+- `diagram.mxgraph.xml`
+- `diagram.png`
+- `diagram-report.json`
+- `diagram-summary.md`
+
+The CLI also prints a JSON result to stdout describing the output directory, provider used, final spec, render report, summary, and artifact paths.
+
+
+## Provider Behavior
+
+- If `OPENAI_API_KEY` is set, `graph-wizard` will attempt to use OpenAI for the first draft.
+- If no API key is configured, or if the OpenAI call fails, the workflow falls back to a deterministic heuristic drafter.
+- The fallback behavior is acceptable and expected in cloud environments where credentials are unavailable.
+
+
+## Validation Workflow
+
+When using this skill, validate in this order:
+
+1. Run:
+   - ```shell
+     export PATH="$HOME/.bun/bin:$PATH"
+     bun run build-client
+     bun run check
+     ```
+2. Run `graph-wizard.ts` with the user's prompt.
+3. Inspect:
+   - stdout JSON
+   - `diagram-report.json`
+   - `diagram-summary.md`
+   - `diagram.png`
+4. If the change affects UI/rendering, manually validate in the browser:
+   - start the server against the generated `diagram.maxgraph.xml`
+   - open normal editor mode
+   - open render-only mode with `?mode=render`
+   - confirm the diagram is legible and the topology is coherent
+
+Recommended manual validation command:
+
+- ```shell
+  export PATH="$HOME/.bun/bin:$PATH"
+  bun src/server.ts "/absolute/path/to/generated/diagram.maxgraph.xml" 3200
+  ```
+
+Then visit:
+
+- `http://127.0.0.1:3200`
+- `http://127.0.0.1:3200/?mode=render`
+
+
+## Output Quality Checklist
+
+Before calling the work done, check:
+
+- nodes referenced by the prompt are present
+- edges form a coherent flow rather than isolated boxes
+- observability/logging nodes are included when the prompt asks for them
+- network/topology prompts do not leave boundary nodes disconnected
+- `diagram.png` is diagram-only and free of editor chrome
+- `diagram-summary.md` explains the result and suggests useful next refinements
+
+
+## Notes For Agents
+
+- Prefer Bun commands directly over `do.nu`.
+- Preserve the generated bundle in `out/`; it is useful evidence.
+- If you improve the workflow itself, update this skill and the project README together.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Bun-native `graph-wizard` CLI that turns a natural-language prompt into a diagram spec, maxGraph XML, mxGraph-compatible XML, PNG render, JSON report, and markdown summary
- add render-only browser mode plus diagram reporting/export helpers so generated diagrams can be rendered and inspected automatically
- refine the heuristic/revision flow so network-topology prompts wire boundary nodes into the main request path instead of leaving them isolated
- add a reusable `graph-wizard` agent skill under `llm-agent/skills/graph-wizard/SKILL.md`
- mirror the skill into `.cursor/skills/graph-wizard/SKILL.md` so Cursor Agent can discover it from the workspace
- document the new Bun/Bash-first workflow and keep Nushell support as a thin wrapper

## Testing
- `bun run build-client`
- `bun run check`
- `bun graph-wizard.ts "please give me a graph of a network topology for how AWS Lambda functions work and please show the logging infrastructure" --provider heuristic --max-iterations 2`
- manual browser validation in editor mode and render-only mode
- `test -f "/workspace/llm-agent/skills/graph-wizard/SKILL.md" && printf 'skill file present\n'`
- `which agent && agent --version && agent --help`
- `agent --print --trust --workspace /workspace "Use the graph-wizard skill to generate a graph of a network topology for how AWS Lambda functions work and show the logging infrastructure. Put the output in javascript/max-graph-editor/out/cli-skill-test."` (blocked by authentication requirement)

## Walkthrough
[graph_wizard_lambda_topology_demo.mp4](https://cursor.com/agents/bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph_wizard_lambda_topology_demo.mp4)
[Graph wizard editor mode](https://cursor.com/agents/bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph_wizard_editor_mode.webp)
[Graph wizard render mode](https://cursor.com/agents/bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph_wizard_render_mode.webp)
[Generated Lambda topology PNG](https://cursor.com/agents/bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph_wizard_lambda_topology.png)

## Notes
- `graph-wizard` uses OpenAI when `OPENAI_API_KEY` is configured and otherwise falls back to a deterministic heuristic drafter
- the tested output bundle includes maxGraph XML, mxGraph-compatible XML, a rendered PNG, a diagram report, and a markdown summary
- the new skill teaches agents when to use the workflow, which files matter, the Bun commands to run, and how to validate output quality
- Cursor Agent installation succeeded, but a real CLI-driven skill run requires interactive `agent login` or `CURSOR_API_KEY`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bf0ed1f-25eb-47f4-97f6-34ac1bd9c6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

