### PR TITLE
Use Nutest for testing

### DIFF
--- a/mac-os/README.md
+++ b/mac-os/README.md
@@ -125,6 +125,10 @@ to a working Nushell environment, but it's great enough.
      * ```nushell
        plugin add nu_plugin_gstat
        ```
+     * Install `nutest` from source and patch a fix for a "spaces in path" problem.
+     * ```nushell
+       do install-nutest
+       ```
 12. Install [Atuin](https://github.com/atuinsh/atuin)
      * Install Atuin and copy over my config with the following commands.
      * ```shell

--- a/mac-os/do.nu
+++ b/mac-os/do.nu
@@ -1,5 +1,13 @@
-const DIR = path self | path dirname
+# I need to source library code by path because this is a bootstrapping problem. On new installs, nothing will be
+# installed into "$nu.default-config-dir/scripts" yet.
+use ../nushell/scripts/zdu.nu err
 
+const DIR = path self | path dirname
+const NUTEST_REPO_URL = "https://github.com/vyadh/nutest.git"
+const NUTEST_COMMIT = "d56fdc632b96754153a014c021d65a6633fc5610"
+
+# Install my LLM rules files
+#
 export def llm-rules [] {
     cd $DIR
 
@@ -35,4 +43,72 @@ export def llm-prompts [] {
     mkdir $prompts_dir
 
     cp -r ../llm-agent/prompts/* $prompts_dir
+}
+
+
+# Install Nutest module from source.
+#
+# Call to action: periodically check the upstream and update `NUTEST_COMMIT` as needed.
+#
+# This command also patches a small problem in Nutest. Nutest dynamically constructs some Nu code with `use/source`
+# commands and executes it, but it is not escaping the path. So for me, I was getting parse-time errors like the following:
+#
+#    use /Users/me/Library/Application Support/nushell/scripts/nutest/runner.nu *
+#       ╰── module /Users/me/Library/Application not found
+#
+export def install-nutest [] {
+    cd $DIR
+
+    let source_parent_dir = "~/repos/opensource" | path expand
+    let source_dir = [$source_parent_dir nutest] | path join
+    let module_parent_dir = [$nu.default-config-dir scripts] | path join
+    let module_dir = [$module_parent_dir nutest] | path join
+
+    mkdir $source_parent_dir
+    mkdir $module_parent_dir
+
+    if ($source_dir | path exists) {
+        ^git -C $source_dir fetch origin
+    } else {
+        ^git clone $NUTEST_REPO_URL $source_dir
+    }
+
+    ^git -C $source_dir checkout --detach $NUTEST_COMMIT
+
+    let checked_out_commit = (^git -C $source_dir rev-parse HEAD | str trim)
+    if ($checked_out_commit != $NUTEST_COMMIT) {
+        err $"Expected Nutest commit ($NUTEST_COMMIT) but checked out ($checked_out_commit)."
+    }
+
+    patch-nutest-file (
+        [$source_dir nutest orchestrator.nu] | path join
+    ) "use ($runner_module) *" "use ($runner_module | to nuon) *"
+    patch-nutest-file (
+        [$source_dir nutest orchestrator.nu] | path join
+    ) "source ($path)" "source ($path | to nuon)"
+    patch-nutest-file (
+        [$source_dir nutest discover.nu] | path join
+    ) '$"source ($file); ($query)"' '$"source ($file | to nuon); ($query)"'
+
+    if ($module_dir | path exists) {
+        rm -r -f $module_dir
+    }
+    cp -r ([$source_dir nutest] | path join) $module_parent_dir
+
+    print $"Nutest commit ($NUTEST_COMMIT) installed to ($module_dir)."
+    print $"Pinned sources saved in ($source_dir)."
+}
+
+# Patch the given Nutest source code file by replacing the "old" string with the "new" one.
+#
+def patch-nutest-file [file: path, old: string, new: string] {
+    let contents = open --raw $file
+
+    if not ($contents | str contains $old) {
+        err $"Expected to patch '($file)' but the target text was not found."
+    }
+
+    $contents
+      | str replace $old $new
+      | save --force --raw $file
 }

--- a/nushell/README.md
+++ b/nushell/README.md
@@ -26,6 +26,15 @@ Miscellaneous notes:
 - ```nushell
   do backup config; do install config
   ```
+- ```nushell
+  run-tests
+  ```
+- ```nushell
+  run-tests --display table
+  ```
+- ```nushell
+  run-tests --match-tests 'explicit remote wins' --display table
+  ```
 
 We want to version control quite a bit. There is a tendency of tools like Nushell itself, Atuin and Starship to generate
 a config file that then becomes your own to manage. That's perfectly fine. And the way I manage it is to version control

--- a/nushell/config.nu
+++ b/nushell/config.nu
@@ -60,6 +60,7 @@ use work-trees.nu *
 use zdu.nu *
 use subject.nu *
 use my-dir.nu *
+use nutest *
 
 # I don't really understand the essential coverage, or purpose, of the directories added to the PATH by the macOS
 # "/usr/libexec/path_helper" tool. But, at the least, I know it adds "/usr/local/bin" to the PATH and I need that.

--- a/nushell/do.nu
+++ b/nushell/do.nu
@@ -187,43 +187,6 @@ export def upstream [name: string@config_names] {
     print $config.upstream_success_msg
 }
 
-def test_files [] {
-    glob ([$DIR tests *.nu] | path join) | sort
-}
-
-def test_names [] {
-    test_files | each { |it|
-        $it
-        | path basename
-        | str replace --regex '\.nu$' ''
-    }
-}
-
-# Run standalone Nushell tests from the 'tests/' directory.
-export def test [name?: string@test_names] {
-    cd $DIR
-
-    let test_files = if ($name | is-empty) {
-        test_files
-    } else {
-        let test_file = [$DIR tests $"($name).nu"] | path join
-        if not ($test_file | path exists) {
-            err $"The test file '($test_file)' does not exist."
-        }
-        [$test_file]
-    }
-
-    if ($test_files | is-empty) {
-        print "No Nushell test files found."
-        return
-    }
-
-    for test_file in $test_files {
-        print $"Running ($test_file | path basename)"
-        ^$nu.current-exe $test_file
-    }
-}
-
 # There are many custom completion scripts and other neat scripts in the official "nu_scripts" repository: https://github.com/nushell/nu_scripts/tree/4eab7ea772f0a288c99a79947dd332efc1884315
 # We need to generate a script that hardcodes the file paths to a local clone of that repository. This script will source
 # the scripts from the local clone. The script is named "nu-scripts-sourcer.nu".

--- a/nushell/tests/my-git-lib-test.nu
+++ b/nushell/tests/my-git-lib-test.nu
@@ -1,53 +1,48 @@
+use std/testing *
 use std/assert
 use ../scripts/my-git-lib.nu *
 
-# Warning: unedited AI output.
-
-def main [] {
-    let test_commands = (
-        scope commands
-        | where ($it.type == "custom") and ($it.name | str starts-with "test ")
-        | get name
-        | each { |test| [$"print 'Running test: ($test)'", $test] }
-        | flatten
-        | str join "; "
-    )
-
-    nu --commands $"source ($env.CURRENT_FILE); ($test_commands)"
-}
-
-def "test explicit remote wins" [] {
+@test
+def "explicit remote wins" [] {
     assert equal (resolve-remote-from-list [origin upstream] origin) "origin"
 }
 
-def "test uses only remote" [] {
+@test
+def "uses only remote" [] {
     assert equal (resolve-remote-from-list [origin]) "origin"
 }
 
-def "test errors when no remotes" [] {
+@test
+def "errors when no remotes" [] {
     assert error { resolve-remote-from-list [] }
 }
 
-def "test errors when multiple remotes and none selected" [] {
+@test
+def "errors when multiple remotes and none selected" [] {
     assert error { resolve-remote-from-list [origin upstream] }
 }
 
-def "test https remote becomes browser url" [] {
+@test
+def "https remote becomes browser url" [] {
     assert equal (remote-url-to-web-url 'https://github.com/dgroomes/my-software.git') 'https://github.com/dgroomes/my-software'
 }
 
-def "test https remote without dot git stays clean" [] {
+@test
+def "https remote without dot git stays clean" [] {
     assert equal (remote-url-to-web-url 'https://github.com/dgroomes/my-software') 'https://github.com/dgroomes/my-software'
 }
 
-def "test scp style remote becomes browser url" [] {
+@test
+def "scp style remote becomes browser url" [] {
     assert equal (remote-url-to-web-url 'git@github.com:dgroomes/my-software.git') 'https://github.com/dgroomes/my-software'
 }
 
-def "test scp style remote without dot git stays clean" [] {
+@test
+def "scp style remote without dot git stays clean" [] {
     assert equal (remote-url-to-web-url 'git@github.com:dgroomes/my-software') 'https://github.com/dgroomes/my-software'
 }
 
-def "test unsupported ssh scheme errors" [] {
+@test
+def "unsupported ssh scheme errors" [] {
     assert error { remote-url-to-web-url 'ssh://git@github.com/dgroomes/my-software.git' }
 }


### PR DESCRIPTION
I did this a while back. Before, I was using a small set of scripting to get the effect of "test discovery" and "test running". And that was a good way to get into testing with Nushell.

Nushell has some builtin `@test` annotations and some internal-only test discovery/running but it is not exposed to the end user, and rightfully so because it is not fully baked yet. One option is to just vendor it into my own code, but another option is to use Nutest, which is a great implementation and by a Nushell contributor. That's what I'm doing here.